### PR TITLE
Fixes for Ashur filtering

### DIFF
--- a/src/main/java/no/rutebanken/marduk/routes/chouette/ChouetteExportNetexRouteBuilder.java
+++ b/src/main/java/no/rutebanken/marduk/routes/chouette/ChouetteExportNetexRouteBuilder.java
@@ -36,10 +36,6 @@ import static no.rutebanken.marduk.Constants.CHOUETTE_REFERENTIAL;
 import static no.rutebanken.marduk.Constants.CORRELATION_ID;
 import static no.rutebanken.marduk.Constants.DATASET_REFERENTIAL;
 import static no.rutebanken.marduk.Constants.FILE_HANDLE;
-import static no.rutebanken.marduk.Constants.FILTERING_NETEX_SOURCE_CHOUETTE;
-import static no.rutebanken.marduk.Constants.FILTERING_NETEX_SOURCE_HEADER;
-import static no.rutebanken.marduk.Constants.FILTERING_PROFILE_AS_IS;
-import static no.rutebanken.marduk.Constants.FILTERING_PROFILE_HEADER;
 import static no.rutebanken.marduk.Constants.JSON_PART;
 import static no.rutebanken.marduk.Constants.PROVIDER_ID;
 import static no.rutebanken.marduk.Constants.VALIDATION_CLIENT_HEADER;
@@ -58,17 +54,14 @@ public class ChouetteExportNetexRouteBuilder extends AbstractChouetteRouteBuilde
     private final String chouetteUrl;
     private final boolean enablePostValidation;
     private final List<String> allowedCodespacesForStopExport;
-    private final boolean ashurFilteringEnabled;
 
     public ChouetteExportNetexRouteBuilder(
             @Value("${chouette.url}") String chouetteUrl,
             @Value("${chouette.enablePostValidation:true}") boolean enablePostValidation,
-            @Value("${chouette.include.stops.codespaces:}") List<String> allowedCodespacesForStopExport,
-            @Value("${ashur.filteringEnabled:false}") boolean ashurFilteringEnabled) {
+            @Value("${chouette.include.stops.codespaces:}") List<String> allowedCodespacesForStopExport) {
         this.chouetteUrl = chouetteUrl;
         this.enablePostValidation = enablePostValidation;
         this.allowedCodespacesForStopExport = allowedCodespacesForStopExport;
-        this.ashurFilteringEnabled = ashurFilteringEnabled;
     }
 
     @Override
@@ -145,50 +138,36 @@ public class ChouetteExportNetexRouteBuilder extends AbstractChouetteRouteBuilde
                 .end()
                 // end choice
                 .end()
-                .to("direct:prepareCommonMetadataHeadersForFilteringAndValidation")
-                .filter(exchange -> ashurFilteringEnabled)
-                    .log(LoggingLevel.INFO, correlation() + "Detected ashur filtering is enabled, triggering filtering process...")
-                    .to("direct:ashurNetexFilterFromChouetteExport")
-                .end()
                 .to("direct:antuNetexPostValidation")
                 .process(e -> JobEvent.providerJobBuilder(e).timetableAction(JobEvent.TimetableAction.EXPORT_NETEX).state(JobEvent.State.OK).build())
                 .routeId("process-successful-export");
 
-        from("direct:prepareCommonMetadataHeadersForFilteringAndValidation")
-            .process(e -> {
-                Provider provider = getProviderRepository().getProvider(e.getIn().getHeader(PROVIDER_ID, Long.class));
-                e.getIn().setHeader(DATASET_REFERENTIAL, provider.getChouetteInfo().getReferential());
-            })
-            .setHeader(VALIDATION_CORRELATION_ID_HEADER, header(CORRELATION_ID));
-
         from("direct:processFailedExport")
-        .process(e -> {
-                    ActionReportWrapper actionReportWrapper = e.getIn().getBody(ActionReportWrapper.class);
-                    if (actionReportWrapper != null && actionReportWrapper.getActionReport() != null && actionReportWrapper.getActionReport().getFailure() != null) {
-                        ActionReportWrapper.Failure failure = actionReportWrapper.getActionReport().getFailure();
-                        if (JobEvent.CHOUETTE_JOB_FAILURE_CODE_NO_DATA_PROCEEDED.equals(failure.getCode())) {
-                            e.getIn().setHeader(Constants.JOB_ERROR_CODE, JobEvent.JOB_ERROR_NETEX_EXPORT_EMPTY);
+                .process(e -> {
+                            ActionReportWrapper actionReportWrapper = e.getIn().getBody(ActionReportWrapper.class);
+                            if (actionReportWrapper != null && actionReportWrapper.getActionReport() != null && actionReportWrapper.getActionReport().getFailure() != null) {
+                                ActionReportWrapper.Failure failure = actionReportWrapper.getActionReport().getFailure();
+                                if (JobEvent.CHOUETTE_JOB_FAILURE_CODE_NO_DATA_PROCEEDED.equals(failure.getCode())) {
+                                    e.getIn().setHeader(Constants.JOB_ERROR_CODE, JobEvent.JOB_ERROR_NETEX_EXPORT_EMPTY);
+                                }
+                            }
                         }
-                    }
-                }
-        )
+                )
                 .log(LoggingLevel.WARN, correlation() + "Netex export failed with error code ${header." + Constants.JOB_ERROR_CODE + "}")
                 .process(e -> JobEvent.providerJobBuilder(e).timetableAction(JobEvent.TimetableAction.EXPORT_NETEX).state(JobEvent.State.FAILED).build())
                 .routeId("process-failed-export");
 
-        // This route is only temporary for simplifying comparison between filtering from Chouette and filtering from ashur.
-        from("direct:ashurNetexFilterFromChouetteExport")
-                .setHeader(FILTERING_PROFILE_HEADER, constant(FILTERING_PROFILE_AS_IS))
-                .setHeader(FILTERING_NETEX_SOURCE_HEADER, constant(FILTERING_NETEX_SOURCE_CHOUETTE))
-                .to("google-pubsub:{{marduk.pubsub.project.id}}:FilterNetexFileQueue")
-                .log(LoggingLevel.INFO, correlation() + "Done sending to Ashur for filtering");
-
         from("direct:antuNetexPostValidation")
                 .to("direct:copyInternalBlobToValidationBucket")
+                .process(e -> {
+                    Provider provider = getProviderRepository().getProvider(e.getIn().getHeader(PROVIDER_ID, Long.class));
+                    e.getIn().setHeader(DATASET_REFERENTIAL, provider.getChouetteInfo().getReferential());
+                })
                 .setHeader(VALIDATION_STAGE_HEADER, constant(VALIDATION_STAGE_EXPORT_NETEX_POSTVALIDATION))
                 .setHeader(VALIDATION_CLIENT_HEADER, constant(VALIDATION_CLIENT_MARDUK))
                 .setHeader(VALIDATION_PROFILE_HEADER, constant(VALIDATION_PROFILE_TIMETABLE))
                 .setHeader(VALIDATION_DATASET_FILE_HANDLE_HEADER, header(FILE_HANDLE))
+                .setHeader(VALIDATION_CORRELATION_ID_HEADER, header(CORRELATION_ID))
                 .to("direct:setNetexValidationProfile")
                 .to("google-pubsub:{{antu.pubsub.project.id}}:AntuNetexValidationQueue")
                 .process(e -> JobEvent.providerJobBuilder(e)
@@ -203,4 +182,6 @@ public class ChouetteExportNetexRouteBuilder extends AbstractChouetteRouteBuilde
     private boolean isAllowedCodespacesForStopExport(String codespace) {
         return allowedCodespacesForStopExport.contains(codespace);
     }
+
+
 }

--- a/src/main/java/no/rutebanken/marduk/routes/file/FileClassificationRouteBuilder.java
+++ b/src/main/java/no/rutebanken/marduk/routes/file/FileClassificationRouteBuilder.java
@@ -41,15 +41,12 @@ public class FileClassificationRouteBuilder extends BaseRouteBuilder {
 
     private final List<String> swedishCodespaces;
     private final List<String> finnishCodespaces;
-    private final boolean ashurFilteringEnabled;
 
     public FileClassificationRouteBuilder(
             @Value("${antu.validation.sweden.codespaces:}") List<String> swedishCodespaces,
-            @Value("${antu.validation.finland.codespaces:OYM}")List<String> finnishCodespaces,
-            @Value("${ashur.filteringEnabled:false}") boolean ashurFilteringEnabled) {
+            @Value("${antu.validation.finland.codespaces:OYM}")List<String> finnishCodespaces) {
         this.swedishCodespaces = swedishCodespaces;
         this.finnishCodespaces = finnishCodespaces;
-        this.ashurFilteringEnabled = ashurFilteringEnabled;
     }
 
     @Override
@@ -154,30 +151,20 @@ public class FileClassificationRouteBuilder extends BaseRouteBuilder {
                 .when(header(IMPORT_TYPE).isEqualTo(IMPORT_TYPE_NETEX_FLEX))
                 .to("direct:flexibleLinesImport")
                 .otherwise()
-                .process(e -> {
-                    Provider provider = getProviderRepository().getProvider(e.getIn().getHeader(PROVIDER_ID, Long.class));
-                    e.getIn().setHeader(DATASET_REFERENTIAL, provider.getChouetteInfo().getReferential());
-                })
                 .to("direct:antuNetexPreValidation")
-                .filter(exchange -> ashurFilteringEnabled)
-                    .log(LoggingLevel.INFO, correlation() + "Detected ashur filtering is enabled, triggering filtering process...")
-                    .to("direct:ashurNetexFilterAfterPreValidation")
-                .end()
                 // launch the import process if this is a GTFS file or if the pre-validation is activated in chouette
                 .filter(PredicateBuilder.or(simple("{{chouette.enablePreValidation:true}}"), header(FILE_TYPE).isEqualTo(FileType.GTFS)))
                 .log(LoggingLevel.INFO, correlation() + "Posting " + FILE_HANDLE + " ${header." + FILE_HANDLE + "} and " + FILE_TYPE + " ${header." + FILE_TYPE + "} on chouette import queue.")
                 .to("google-pubsub:{{marduk.pubsub.project.id}}:ChouetteImportQueue")
                 .routeId("process-valid-file");
 
-        from("direct:ashurNetexFilterAfterPreValidation")
-                .setHeader(FILTERING_PROFILE_HEADER, constant(FILTERING_PROFILE_STANDARD_IMPORT))
-                .setHeader(FILTERING_NETEX_SOURCE_HEADER, constant(FILTERING_NETEX_SOURCE_MARDUK))
-                .to("google-pubsub:{{marduk.pubsub.project.id}}:FilterNetexFileQueue")
-                .log(LoggingLevel.INFO, correlation() + "Done sending to Ashur for filtering");
-
         from("direct:antuNetexPreValidation")
                 .filter(header(FILE_TYPE).isEqualTo(FileType.NETEXPROFILE))
                 .to("direct:copyInternalBlobToValidationBucket")
+                .process(e -> {
+                    Provider provider = getProviderRepository().getProvider(e.getIn().getHeader(PROVIDER_ID, Long.class));
+                    e.getIn().setHeader(DATASET_REFERENTIAL, provider.getChouetteInfo().getReferential());
+                })
                 .setHeader(VALIDATION_DATASET_FILE_HANDLE_HEADER, header(FILE_HANDLE))
                 .setHeader(VALIDATION_CORRELATION_ID_HEADER, header(CORRELATION_ID))
                 .setHeader(VALIDATION_CLIENT_HEADER, constant(VALIDATION_CLIENT_MARDUK))


### PR DESCRIPTION
* Reverts changes previously made to ChouetteExportNetexRouteBuilder and FileClassificationRouteBuilder, as they caused validation and filtering to happen in parallel
* Changes triggering of filtering in ashur such that it happens after pre- and post-validation stages are done
* Implements copying of netex dataset from internal to marduk's exchange bucket such that ashur will be able to get it