### PR TITLE
Remove support for RoR tenant in OAuth2 configuration

### DIFF
--- a/helm/marduk/env/values-kub-ent-dev.yaml
+++ b/helm/marduk/env/values-kub-ent-dev.yaml
@@ -65,11 +65,8 @@ otp:
 auth0:
   partner:
     url: https://partner.dev.entur.org
-    audience: https://api.dev.entur.io
+    audience: https://api.dev.entur.io,https://ror.api.dev.entur.io
     administratorAccessEnabled: true
-  ror:
-    url: https://ror-entur-dev.eu.auth0.com
-    audience: https://ror.api.dev.entur.io
 
 roleAssignmentExtractor: baba
 

--- a/helm/marduk/env/values-kub-ent-prd.yaml
+++ b/helm/marduk/env/values-kub-ent-prd.yaml
@@ -64,11 +64,8 @@ otp:
 auth0:
   partner:
     url: https://partner.entur.org
-    audience: https://api.entur.io
+    audience: https://api.entur.io,https://ror.api.entur.io
     administratorAccessEnabled: false
-  ror:
-    url: https://auth2.entur.org
-    audience: https://ror.api.entur.io
 
 roleAssignmentExtractor: baba
 

--- a/helm/marduk/env/values-kub-ent-tst.yaml
+++ b/helm/marduk/env/values-kub-ent-tst.yaml
@@ -64,11 +64,8 @@ otp:
 auth0:
   partner:
     url: https://partner.staging.entur.org
-    audience: https://api.staging.entur.io
+    audience: https://api.staging.entur.io,https://ror.api.staging.entur.io
     administratorAccessEnabled: false
-  ror:
-    url: https://ror-entur-staging.eu.auth0.com
-    audience: https://ror.api.staging.entur.io
 
 roleAssignmentExtractor: baba
 

--- a/helm/marduk/templates/configmap.yaml
+++ b/helm/marduk/templates/configmap.yaml
@@ -89,10 +89,6 @@ data:
     marduk.oauth2.resourceserver.auth0.partner.jwt.issuer-uri={{ .Values.auth0.partner.url }}/
     marduk.oauth2.resourceserver.auth0.partner.jwt.audience={{ .Values.auth0.partner.audience }}
 
-    marduk.oauth2.resourceserver.auth0.ror.jwt.issuer-uri={{ .Values.auth0.ror.url }}/
-    marduk.oauth2.resourceserver.auth0.ror.jwt.audience={{ .Values.auth0.ror.audience }}
-    marduk.oauth2.resourceserver.auth0.ror.claim.namespace=https://ror.entur.io/
-
     # OAuth2 Client
     spring.security.oauth2.client.registration.marduk.authorization-grant-type=client_credentials
     spring.security.oauth2.client.registration.marduk.client-id={{ .Values.oauth2.client.id }}

--- a/src/main/java/no/rutebanken/marduk/security/oauth2/MardukWebSecurityConfiguration.java
+++ b/src/main/java/no/rutebanken/marduk/security/oauth2/MardukWebSecurityConfiguration.java
@@ -23,9 +23,8 @@ import static org.springframework.security.config.Customizer.withDefaults;
 /**
  * Authentication and authorization configuration for Marduk.
  * All requests must be authenticated except for the OpenAPI endpoint.
- * The OAuth2 ID-provider (Entur Partner Auth0 or RoR Auth0) is identified using
+ * The OAuth2 ID-provider (Entur Partner Auth0) is identified using
  * {@link MultiIssuerAuthenticationManagerResolver} with multi-audience support.
- * The Entur Partner Auth0 decoder accepts both partner and RoR audiences.
  */
 @Profile("!test")
 @EnableWebSecurity
@@ -45,18 +44,12 @@ public class MardukWebSecurityConfiguration {
 
     @Bean
     public MultiIssuerAuthenticationManagerResolver multiIssuerResolver(
-            @Value("${marduk.oauth2.resourceserver.auth0.partner.jwt.audience}") String enturPartnerAuth0Audience,
-            @Value("${marduk.oauth2.resourceserver.auth0.partner.jwt.issuer-uri}") String enturPartnerAuth0Issuer,
-            @Value("${marduk.oauth2.resourceserver.auth0.ror.jwt.audience}") String rorAuth0Audience,
-            @Value("${marduk.oauth2.resourceserver.auth0.ror.jwt.issuer-uri}") String rorAuth0Issuer,
-            @Value("${marduk.oauth2.resourceserver.auth0.ror.claim.namespace}") String rorAuth0ClaimNamespace) {
+            @Value("${marduk.oauth2.resourceserver.auth0.partner.jwt.audience}") String enturPartnerAuth0Audiences,
+            @Value("${marduk.oauth2.resourceserver.auth0.partner.jwt.issuer-uri}") String enturPartnerAuth0Issuer) {
 
         return new MultiIssuerAuthenticationManagerResolverBuilder()
-                .withEnturPartnerAuth0Audiences(List.of(enturPartnerAuth0Audience, rorAuth0Audience))
+                .withEnturPartnerAuth0Audiences(Arrays.asList(enturPartnerAuth0Audiences.split(",")))
                 .withEnturPartnerAuth0Issuer(enturPartnerAuth0Issuer)
-                .withRorAuth0Audience(rorAuth0Audience)
-                .withRorAuth0Issuer(rorAuth0Issuer)
-                .withRorAuth0ClaimNamespace(rorAuth0ClaimNamespace)
                 .build();
     }
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -80,12 +80,7 @@ netex.export.merge.flexible.lines.enabled=true
 
 # OAuth2 Resource Server for Entur Partner tenant
 marduk.oauth2.resourceserver.auth0.partner.jwt.issuer-uri=http://notinuse
-marduk.oauth2.resourceserver.auth0.partner.jwt.audience=notinuse
-
-# OAuth2 Resource Server for RoR tenant
-marduk.oauth2.resourceserver.auth0.ror.jwt.issuer-uri=http://notinuse
-marduk.oauth2.resourceserver.auth0.ror.jwt.audience=notinuse
-marduk.oauth2.resourceserver.auth0.ror.claim.namespace=notinuse
+marduk.oauth2.resourceserver.auth0.partner.jwt.audience=notinuse,notinuse
 
 # OAuth2 Client
 spring.security.oauth2.client.registration.marduk.authorization-grant-type=client_credentials


### PR DESCRIPTION
## Summary
- Consolidated RoR tenant authentication into Entur Partner tenant configuration
- Removed separate OAuth2 resource server configurations for RoR tenant
- Updated configuration to use comma-separated audiences instead of separate tenant configurations

## Changes
- **Helm values files** (dev, prd, tst): Removed separate `auth0.ror` section and consolidated audiences into `auth0.partner.audience`
- **configmap.yaml**: Removed RoR-specific OAuth2 resource server properties
- **MardukWebSecurityConfiguration.java**: Removed RoR-specific parameters and methods, updated to accept comma-separated audiences
- **application.properties** (test): Removed RoR OAuth2 resource server properties

## Approach
This follows the same approach used in entur/baba#651, simplifying the authentication setup while maintaining support for both API audiences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)