### PR TITLE
Migrate from JwtUserInfoExtractor to DefaultJwtUserInfoExtractor

### DIFF
--- a/src/main/java/no/rutebanken/marduk/config/AuthorizationConfig.java
+++ b/src/main/java/no/rutebanken/marduk/config/AuthorizationConfig.java
@@ -20,7 +20,7 @@ import no.rutebanken.marduk.repository.ProviderRepository;
 import no.rutebanken.marduk.security.DefaultMardukAuthorizationService;
 import no.rutebanken.marduk.security.MardukAuthorizationService;
 import org.entur.oauth2.JwtRoleAssignmentExtractor;
-import org.entur.oauth2.user.JwtUserInfoExtractor;
+import org.entur.oauth2.user.DefaultJwtUserInfoExtractor;
 import org.entur.ror.permission.RemoteBabaRoleAssignmentExtractor;
 import org.entur.ror.permission.RemoteBabaUserInfoExtractor;
 import org.rutebanken.helper.organisation.RoleAssignmentExtractor;
@@ -48,7 +48,7 @@ public class AuthorizationConfig {
     )
     @Bean
     public UserInfoExtractor jwtUserInfoExtractor() {
-        return new JwtUserInfoExtractor();
+        return new DefaultJwtUserInfoExtractor();
     }
 
     @ConditionalOnProperty(


### PR DESCRIPTION
## Summary

- Replace deprecated `JwtUserInfoExtractor` with `DefaultJwtUserInfoExtractor`
- Update import statement to use the new class
- This migration follows the completion of the Auth0 tenant migration from legacy RoR tenant to Entur Partner tenant

## Context

The Auth0 tenant migration changed JWT token claims from custom namespaced claims (`https://ror.entur.io/preferred_username`) to standard OIDC claims (`preferred_username`). The `DefaultJwtUserInfoExtractor` class extracts user information from these standard OIDC claims.

The deprecated `JwtUserInfoExtractor` and `EnturJwtUserInfoExtractor` classes have been removed from rutebanken-helpers as of December 2, 2025.

## Changes

- Updated `AuthorizationConfig.java`:
  - Changed import from `org.entur.oauth2.user.JwtUserInfoExtractor`
  - To: `org.entur.oauth2.user.DefaultJwtUserInfoExtractor`
  - Updated bean instantiation to use new class

## Test plan

- [x] Code compiles successfully
- [x] All unit tests pass (`mvn clean verify`)
- [x] No behavioral changes expected - same interface, standard OIDC claims
- [ ] Verify authentication works in deployed environment
- [ ] Monitor authentication logs after deployment