### PR TITLE
Aligns timestamps in CompositeFrame and nisaba

### DIFF
--- a/src/main/java/no/rutebanken/marduk/routes/chouette/AntuNetexValidationStatusRouteBuilder.java
+++ b/src/main/java/no/rutebanken/marduk/routes/chouette/AntuNetexValidationStatusRouteBuilder.java
@@ -19,6 +19,7 @@ package no.rutebanken.marduk.routes.chouette;
 import no.rutebanken.marduk.Constants;
 import no.rutebanken.marduk.repository.FileNameAndDigestIdempotentRepository;
 import no.rutebanken.marduk.routes.experimental.ExperimentalImportHelpers;
+import no.rutebanken.marduk.routes.experimental.FilteringTimestampProcessor;
 import no.rutebanken.marduk.routes.experimental.NisabaHeadersProcessor;
 import no.rutebanken.marduk.routes.file.FileType;
 import no.rutebanken.marduk.routes.processors.PrevalidatedFileMetadataProcessor;
@@ -167,6 +168,7 @@ public class AntuNetexValidationStatusRouteBuilder extends AbstractChouetteRoute
                 .choice()
 
                 .when(and(header(VALIDATION_STAGE_HEADER).isEqualTo(VALIDATION_STAGE_PREVALIDATION), experimentalImportHelpers::shouldRunExperimentalImport))
+                    .process(new FilteringTimestampProcessor(fileNameAndDigestIdempotentRepository))
                     .to("direct:uploadOriginalDatasetToNisaba")
                     // Store original FILE_HANDLE before writing metadata
                     .setProperty("originalFileHandle", header(FILE_HANDLE))

--- a/src/main/java/no/rutebanken/marduk/routes/experimental/FilteringTimestampProcessor.java
+++ b/src/main/java/no/rutebanken/marduk/routes/experimental/FilteringTimestampProcessor.java
@@ -1,0 +1,45 @@
+package no.rutebanken.marduk.routes.experimental;
+
+import no.rutebanken.marduk.repository.FileNameAndDigestIdempotentRepository;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDateTime;
+
+import static no.rutebanken.marduk.Constants.FILE_NAME;
+import static no.rutebanken.marduk.Constants.FILTERING_FILE_CREATED_TIMESTAMP;
+
+/**
+ * Processor that resolves the createdAt timestamp for a file from the idempotent repository
+ * and sets it as the FILTERING_FILE_CREATED_TIMESTAMP header.
+ * This timestamp is used by downstream processors (e.g. NisabaHeadersProcessor, Ashur)
+ * to ensure consistent naming across the pipeline.
+ */
+public class FilteringTimestampProcessor implements Processor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FilteringTimestampProcessor.class);
+
+    private final FileNameAndDigestIdempotentRepository fileNameAndDigestIdempotentRepository;
+
+    public FilteringTimestampProcessor(FileNameAndDigestIdempotentRepository fileNameAndDigestIdempotentRepository) {
+        this.fileNameAndDigestIdempotentRepository = fileNameAndDigestIdempotentRepository;
+    }
+
+    @Override
+    public void process(Exchange exchange) {
+        String fileName = exchange.getIn().getHeader(FILE_NAME, String.class);
+        LOGGER.info("Looking up createdAt timestamp for file '{}'", fileName);
+
+        LocalDateTime createdAt = fileNameAndDigestIdempotentRepository.getCreatedAt(fileName);
+        if (createdAt != null) {
+            LOGGER.info("Found createdAt timestamp {} in idempotent repository for file '{}'", createdAt, fileName);
+        } else {
+            createdAt = LocalDateTime.now();
+            LOGGER.warn("No createdAt timestamp found in idempotent repository for file '{}', falling back to current time: {}", fileName, createdAt);
+        }
+
+        exchange.getIn().setHeader(FILTERING_FILE_CREATED_TIMESTAMP, createdAt.toString());
+    }
+}

--- a/src/main/java/no/rutebanken/marduk/routes/experimental/NisabaHeadersProcessor.java
+++ b/src/main/java/no/rutebanken/marduk/routes/experimental/NisabaHeadersProcessor.java
@@ -3,9 +3,13 @@ package no.rutebanken.marduk.routes.experimental;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
 
 import static no.rutebanken.marduk.Constants.*;
@@ -14,6 +18,7 @@ import static no.rutebanken.marduk.Constants.*;
  * Processor used to set headers for files being uploaded to the Nisaba exchange bucket.
  * */
 public class NisabaHeadersProcessor implements Processor {
+    private static final Logger LOGGER = LoggerFactory.getLogger(NisabaHeadersProcessor.class);
     private final String containerName;
 
     public NisabaHeadersProcessor(String containerName) {
@@ -26,10 +31,29 @@ public class NisabaHeadersProcessor implements Processor {
                 .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
                 .appendFraction(ChronoField.NANO_OF_SECOND, 0, 3, true)
                 .toFormatter();
-        String timestamp = LocalDateTime.now().format(fmt).replace(":", "_");
-        String targetFileName = "/" + exchange.getIn().getHeader(CHOUETTE_REFERENTIAL, String.class) + "_" + timestamp + ".zip";
-        String pathToTargetFile = "imported/" + exchange.getIn().getHeader(CHOUETTE_REFERENTIAL, String.class) + targetFileName;
+        LocalDateTime dateTime = resolveTimestamp(exchange);
+        String timestamp = dateTime.format(fmt).replace(":", "_");
+        String referential = exchange.getIn().getHeader(CHOUETTE_REFERENTIAL, String.class);
+        String targetFileName = "/" + referential + "_" + timestamp + ".zip";
+        String pathToTargetFile = "imported/" + referential + targetFileName;
         exchange.getIn().setHeader(TARGET_FILE_HANDLE, pathToTargetFile);
         exchange.getIn().setHeader(TARGET_CONTAINER, containerName);
+        LOGGER.info("Set Nisaba upload target: container='{}', fileHandle='{}'", containerName, pathToTargetFile);
+    }
+
+    private LocalDateTime resolveTimestamp(Exchange exchange) {
+        String headerValue = exchange.getIn().getHeader(FILTERING_FILE_CREATED_TIMESTAMP, String.class);
+        if (headerValue != null) {
+            try {
+                LocalDateTime parsed = LocalDateTime.parse(headerValue);
+                LOGGER.info("Using timestamp from {} header: {}", FILTERING_FILE_CREATED_TIMESTAMP, parsed);
+                return parsed;
+            } catch (DateTimeParseException e) {
+                LOGGER.warn("Failed to parse {} header value '{}', falling back to current time", FILTERING_FILE_CREATED_TIMESTAMP, headerValue, e);
+            }
+        } else {
+            LOGGER.info("No {} header present, falling back to current time", FILTERING_FILE_CREATED_TIMESTAMP);
+        }
+        return LocalDateTime.now();
     }
 }

--- a/src/test/java/no/rutebanken/marduk/routes/experimental/FilteringTimestampProcessorTest.java
+++ b/src/test/java/no/rutebanken/marduk/routes/experimental/FilteringTimestampProcessorTest.java
@@ -1,0 +1,61 @@
+package no.rutebanken.marduk.routes.experimental;
+
+import no.rutebanken.marduk.repository.FileNameAndDigestIdempotentRepository;
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static no.rutebanken.marduk.Constants.FILE_NAME;
+import static no.rutebanken.marduk.Constants.FILTERING_FILE_CREATED_TIMESTAMP;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class FilteringTimestampProcessorTest {
+
+    private Exchange exchange() {
+        CamelContext ctx = new DefaultCamelContext();
+        return new DefaultExchange(ctx);
+    }
+
+    @Test
+    void testProcessorUsesTimestampFromRepository() {
+        FileNameAndDigestIdempotentRepository repository = mock(FileNameAndDigestIdempotentRepository.class);
+        LocalDateTime expectedTimestamp = LocalDateTime.of(2025, 6, 15, 10, 30, 45, 123000000);
+        String fileName = "test-file.zip";
+        when(repository.getCreatedAt(fileName)).thenReturn(expectedTimestamp);
+
+        FilteringTimestampProcessor processor = new FilteringTimestampProcessor(repository);
+        Exchange exchange = exchange();
+        exchange.getIn().setHeader(FILE_NAME, fileName);
+        processor.process(exchange);
+
+        String headerValue = exchange.getIn().getHeader(FILTERING_FILE_CREATED_TIMESTAMP, String.class);
+        Assertions.assertEquals(expectedTimestamp.toString(), headerValue);
+    }
+
+    @Test
+    void testProcessorFallsBackToCurrentTimeWhenRepositoryReturnsNull() {
+        FileNameAndDigestIdempotentRepository repository = mock(FileNameAndDigestIdempotentRepository.class);
+        String fileName = "test-file.zip";
+        when(repository.getCreatedAt(fileName)).thenReturn(null);
+
+        FilteringTimestampProcessor processor = new FilteringTimestampProcessor(repository);
+        Exchange exchange = exchange();
+        exchange.getIn().setHeader(FILE_NAME, fileName);
+
+        LocalDateTime before = LocalDateTime.now();
+        processor.process(exchange);
+        LocalDateTime after = LocalDateTime.now();
+
+        String headerValue = exchange.getIn().getHeader(FILTERING_FILE_CREATED_TIMESTAMP, String.class);
+        Assertions.assertNotNull(headerValue);
+        LocalDateTime actual = LocalDateTime.parse(headerValue);
+        Assertions.assertFalse(actual.isBefore(before));
+        Assertions.assertFalse(actual.isAfter(after));
+    }
+}

--- a/src/test/java/no/rutebanken/marduk/routes/experimental/NisabaHeadersProcessorTest.java
+++ b/src/test/java/no/rutebanken/marduk/routes/experimental/NisabaHeadersProcessorTest.java
@@ -7,6 +7,8 @@ import org.apache.camel.support.DefaultExchange;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
+
 import static no.rutebanken.marduk.Constants.*;
 
 class NisabaHeadersProcessorTest {
@@ -16,7 +18,7 @@ class NisabaHeadersProcessorTest {
     }
 
     @Test
-    void testProcessor() throws Exception {
+    void testProcessorWithoutTimestampHeader() throws Exception {
         String testContainerName = "nisaba-exchange-bucket";
         NisabaHeadersProcessor processor = new NisabaHeadersProcessor(testContainerName);
         Exchange exchange = exchange();
@@ -27,5 +29,20 @@ class NisabaHeadersProcessorTest {
         String fileHandle = exchange.getIn().getHeader(TARGET_FILE_HANDLE, String.class);
         Assertions.assertTrue(fileHandle.startsWith("imported/tst/tst_"));
         Assertions.assertTrue(fileHandle.endsWith(".zip"));
+    }
+
+    @Test
+    void testProcessorUsesTimestampHeader() throws Exception {
+        String testContainerName = "nisaba-exchange-bucket";
+        NisabaHeadersProcessor processor = new NisabaHeadersProcessor(testContainerName);
+        Exchange exchange = exchange();
+        exchange.getIn().setHeader(CHOUETTE_REFERENTIAL, "tst");
+        LocalDateTime fixedTime = LocalDateTime.of(2025, 6, 15, 10, 30, 45, 123000000);
+        exchange.getIn().setHeader(FILTERING_FILE_CREATED_TIMESTAMP, fixedTime.toString());
+        processor.process(exchange);
+
+        Assertions.assertEquals(testContainerName, exchange.getIn().getHeader(TARGET_CONTAINER));
+        String fileHandle = exchange.getIn().getHeader(TARGET_FILE_HANDLE, String.class);
+        Assertions.assertEquals("imported/tst/tst_2025-06-15T10_30_45.123.zip", fileHandle);
     }
 }


### PR DESCRIPTION
Fixes a regression in the experimental import, which resulted in nisaba failing in matching it's netex .zip file with the aggregated netex file placed in marduk's outbound bucket for that same codespace and import process. The issue was caused by timestamps not being synced between the two when using the experimental import:
* when naming the .zip file copied to nisaba-exchange, the experimental import would use LocalDateTime.now() in the resulting zip file name
* when producing CompositeFrame elements through Ashur, the experimental import would use the createdAt value from the idempotentRepository for the file being imported

This commit fixes this inconsistency by using the same createdAt timestamp as Ashur for naming the zip file copied to nisaba-exchange

Not directly related to this commit, but important to note: The timestamps in the zip file names copied to nisaba use millisecond precision. When producing this timestamp, it is important to ensure that microsecond precision is truncated from the timestamp, rather than having the millisecond be rounded up. This is already handled in a correct way by marduk.