### PR TITLE
Fixes flexible merging regression

### DIFF
--- a/src/main/java/no/rutebanken/marduk/routes/chouette/AntuNetexValidationStatusRouteBuilder.java
+++ b/src/main/java/no/rutebanken/marduk/routes/chouette/AntuNetexValidationStatusRouteBuilder.java
@@ -211,6 +211,11 @@ public class AntuNetexValidationStatusRouteBuilder extends AbstractChouetteRoute
                     .setHeader(FILE_HANDLE).method(experimentalImportHelpers, "pathToNetexWithoutBlocksProducedByAshur")
                     .setHeader(TARGET_FILE_HANDLE).method(experimentalImportHelpers, "pathToNetexFromAshurToMergeWithFlex")
                     .to("direct:copyInternalBlobInBucket")
+                    // Also publish the without-blocks Ashur output at a stable per-referential path so a
+                    // later cross-flow merge (e.g. after FLEX post-validation, which carries the FLEX
+                    // import's correlation id) can locate the latest ordinary NeTEx for this codespace.
+                    .setHeader(TARGET_FILE_HANDLE).method(experimentalImportHelpers, "pathToLatestNetexWithoutBlocksFromAshur")
+                    .to("direct:copyInternalBlobInBucket")
                     .to("google-pubsub:{{marduk.pubsub.project.id}}:ChouetteMergeWithFlexibleLinesQueue")
                     .process(e -> e.setProperty("exportBlocks", getProviderRepository().getProvider(e.getIn().getHeader(PROVIDER_ID, Long.class)).getChouetteInfo().isEnableBlocksExport()))
                     .choice()

--- a/src/main/java/no/rutebanken/marduk/routes/experimental/ExperimentalImportHelpers.java
+++ b/src/main/java/no/rutebanken/marduk/routes/experimental/ExperimentalImportHelpers.java
@@ -119,6 +119,19 @@ public class ExperimentalImportHelpers {
         return "filtered-netex/" + referential + "/netex-before-merging/" + correlationIdFor(exchange) + "/" + referential + "-" + Constants.CURRENT_AGGREGATED_NETEX_FILENAME;
     }
 
+    /**
+     * Stable per-referential path holding the most recent Ashur StandardImportFilter output
+     * (i.e. the without-blocks ordinary NeTEx) for the codespace.
+     * Used as a fallback when the merge route is triggered from a different correlation (e.g. after a
+     * FLEX post-validation) and the correlation-keyed path from {@link #pathToNetexFromAshurToMergeWithFlex}
+     * does not contain a matching file. Must NOT receive the with-blocks output.
+     */
+    @SuppressWarnings("unused") // Used by AntuNetexValidationStatusRouteBuilder and NetexMergeChouetteWithFlexibleLineExportRouteBuilder
+    public String pathToLatestNetexWithoutBlocksFromAshur(Exchange exchange) {
+        String referential = chouetteReferentialFor(exchange);
+        return "filtered-netex/" + referential + "/latest-without-blocks/" + referential + "-" + Constants.CURRENT_AGGREGATED_NETEX_FILENAME;
+    }
+
     @SuppressWarnings("unused") // Used by AntuNetexValidationStatusRouteBuilder and AshurFilteringStatusRouteBuilder
     public String pathToNetexWithoutBlocksProducedByAshur(Exchange exchange) {
         String referential = chouetteReferentialFor(exchange);

--- a/src/main/java/no/rutebanken/marduk/routes/netex/NetexMergeChouetteWithFlexibleLineExportRouteBuilder.java
+++ b/src/main/java/no/rutebanken/marduk/routes/netex/NetexMergeChouetteWithFlexibleLineExportRouteBuilder.java
@@ -147,8 +147,29 @@ public class NetexMergeChouetteWithFlexibleLineExportRouteBuilder extends BaseRo
                 .process(e -> ZipFileUtils.unzipFile(e.getIn().getBody(InputStream.class), experimentalImportHelpers.flexibleDataWorkingDirectory(e)))
                 .setProperty(PROP_HAS_CHOUETTE_DATA, constant("true"))
                 .otherwise()
-                .log(LoggingLevel.INFO, getClass().getName(), correlation() + "${header." + FILE_HANDLE + "} was empty when trying to fetch it from blobstore.")
+                .to("direct:tryFallbackToLatestAshurOutput")
                 .routeId("netex-export-merge-chouette-with-flexible-lines-unpack-chouette-export");
+
+        // Fallback in a sub-route to avoid nested choice() (same pattern as direct:unpackFlexibleLinesExportToWorkingFolder).
+        // Only used for experimental codespaces, where the merge can be triggered from a different correlation
+        // (e.g. FLEX post-validation) and the correlation-keyed path therefore points to no file.
+        from("direct:tryFallbackToLatestAshurOutput")
+                .choice().when(experimentalImportHelpers::shouldRunExperimentalImport)
+                .to("direct:doFallbackToLatestAshurOutput")
+                .otherwise()
+                .log(LoggingLevel.INFO, getClass().getName(), correlation() + "${header." + FILE_HANDLE + "} was empty when trying to fetch it from blobstore.")
+                .routeId("netex-export-merge-chouette-with-flexible-lines-try-fallback-to-latest-ashur-output");
+
+        from("direct:doFallbackToLatestAshurOutput")
+                .setHeader(FILE_HANDLE).method(experimentalImportHelpers, "pathToLatestNetexWithoutBlocksFromAshur")
+                .to("direct:getInternalBlob")
+                .choice()
+                .when(body().isNotEqualTo(null))
+                .process(e -> ZipFileUtils.unzipFile(e.getIn().getBody(InputStream.class), experimentalImportHelpers.flexibleDataWorkingDirectory(e)))
+                .setProperty(PROP_HAS_CHOUETTE_DATA, constant("true"))
+                .otherwise()
+                .log(LoggingLevel.INFO, getClass().getName(), correlation() + "${header." + FILE_HANDLE + "} fallback was empty when trying to fetch latest Ashur output from blobstore.")
+                .routeId("netex-export-merge-chouette-with-flexible-lines-do-fallback-to-latest-ashur-output");
 
 
         from("direct:unpackFlexibleLinesExportToWorkingFolder")

--- a/src/test/java/no/rutebanken/marduk/routes/chouette/AntuNetexValidationStatusRouteBuilderTest.java
+++ b/src/test/java/no/rutebanken/marduk/routes/chouette/AntuNetexValidationStatusRouteBuilderTest.java
@@ -1,13 +1,18 @@
 package no.rutebanken.marduk.routes.chouette;
 
 import no.rutebanken.marduk.MardukRouteBuilderIntegrationTestBase;
+import no.rutebanken.marduk.TestConstants;
+import no.rutebanken.marduk.domain.ChouetteInfo;
+import no.rutebanken.marduk.domain.Provider;
 import no.rutebanken.marduk.routes.status.JobEvent;
 import org.apache.camel.*;
 import org.apache.camel.builder.AdviceWith;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
 
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -17,7 +22,9 @@ import static no.rutebanken.marduk.Constants.*;
 import static no.rutebanken.marduk.routes.chouette.AntuNetexValidationStatusRouteBuilder.STATUS_VALIDATION_FAILED;
 import static no.rutebanken.marduk.routes.chouette.AntuNetexValidationStatusRouteBuilder.STATUS_VALIDATION_OK;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
 
+@TestPropertySource(properties = {"marduk.experimental-import.enabled=true"})
 class AntuNetexValidationStatusRouteBuilderTest extends MardukRouteBuilderIntegrationTestBase {
 
     @Produce("google-pubsub:{{marduk.pubsub.project.id}}:AntuNetexValidationStatusQueue")
@@ -40,6 +47,18 @@ class AntuNetexValidationStatusRouteBuilderTest extends MardukRouteBuilderIntegr
 
     @EndpointInject("mock:publishMergedNetexQueue")
     protected MockEndpoint publishMergedNetexQueueMock;
+
+    @EndpointInject("mock:antuNetexValidationQueueMerged")
+    protected MockEndpoint antuNetexValidationQueueMergedMock;
+
+    @EndpointInject("mock:otp2GraphBuildQueue")
+    protected MockEndpoint otp2GraphBuildQueueMock;
+
+    @EndpointInject("mock:netexExportNotificationQueue")
+    protected MockEndpoint netexExportNotificationQueueMock;
+
+    @EndpointInject("mock:gtfsRouteDispatcherTopic")
+    protected MockEndpoint gtfsRouteDispatcherTopicMock;
 
     @BeforeEach
     protected void setUp() throws IOException {
@@ -208,5 +227,111 @@ class AntuNetexValidationStatusRouteBuilderTest extends MardukRouteBuilderIntegr
         assertTrue(events.stream().anyMatch(je ->
             JobEvent.TimetableAction.EXPORT_NETEX_MERGED_POSTVALIDATION.name().equals(je.getAction())
             && JobEvent.State.OK.equals(je.getState())));
+    }
+
+    /**
+     * Regression guard: when a FLEX post-validation OK arrives for an experimental codespace and the latest
+     * Ashur ordinary NeTEx exists at the stable per-referential path (but NOT at the FLEX correlation-keyed
+     * path, since the flex import has a different correlation id than the most recent ordinary import),
+     * the merge route must still produce both a chouette- and a flex-source and route through the merged
+     * post-validation step instead of publishing straight to the OTP2 graph build queue.
+     */
+    @Test
+    void testFlexPostValidationForExperimentalCodespaceTriggersMergedValidationViaLatestAshurFallback() throws Exception {
+        // Override default provider mocks so rb_rut is an experimental codespace.
+        Provider experimentalRutProvider = new Provider();
+        experimentalRutProvider.setId(TestConstants.PROVIDER_ID_RUT);
+        ChouetteInfo rutInfo = new ChouetteInfo();
+        rutInfo.setId(TestConstants.PROVIDER_ID_RUT);
+        rutInfo.setReferential(TestConstants.CHOUETTE_REFERENTIAL_RUT);
+        rutInfo.setEnableExperimentalImport(true);
+        experimentalRutProvider.setChouetteInfo(rutInfo);
+
+        Provider experimentalRbRutProvider = new Provider();
+        experimentalRbRutProvider.setId(TestConstants.PROVIDER_ID_RB_RUT);
+        ChouetteInfo rbRutInfo = new ChouetteInfo();
+        rbRutInfo.setId(TestConstants.PROVIDER_ID_RB_RUT);
+        rbRutInfo.setReferential(TestConstants.CHOUETTE_REFERENTIAL_RB_RUT);
+        rbRutInfo.setEnableExperimentalImport(true);
+        experimentalRbRutProvider.setChouetteInfo(rbRutInfo);
+
+        when(providerRepository.getProvider(TestConstants.PROVIDER_ID_RUT)).thenReturn(experimentalRutProvider);
+        when(providerRepository.getProvider(TestConstants.PROVIDER_ID_RB_RUT)).thenReturn(experimentalRbRutProvider);
+        when(providerRepository.getProviders()).thenReturn(List.of(experimentalRutProvider, experimentalRbRutProvider));
+        when(providerRepository.getProviderId(TestConstants.CHOUETTE_REFERENTIAL_RUT)).thenReturn(TestConstants.PROVIDER_ID_RUT);
+        when(providerRepository.getProviderId(TestConstants.CHOUETTE_REFERENTIAL_RB_RUT)).thenReturn(TestConstants.PROVIDER_ID_RB_RUT);
+
+        // Simulated state from a previous successful experimental ordinary import:
+        // the latest Ashur StandardImportFilter output is at the stable per-referential path.
+        // No file is placed at the FLEX correlation-keyed path - that's the whole point of the regression.
+        String stableLatestAshurPath = "filtered-netex/rb_rut/latest-without-blocks/rb_rut-aggregated-netex.zip";
+        internalInMemoryBlobStoreRepository.uploadBlob(
+                stableLatestAshurPath,
+                new FileInputStream("src/test/resources/no/rutebanken/marduk/routes/file/beans/netex.zip"));
+
+        // Pre-populate the flex file at the destination path the merge route reads from.
+        // The FLEX post-validation handler also copies it there, but we mock that copy to keep the test focused.
+        String flexOutboundPath = BLOBSTORE_PATH_OUTBOUND + "netex/rb_rut-" + CURRENT_FLEXIBLE_LINES_NETEX_FILENAME;
+        exchangeInMemoryBlobStoreRepository.uploadBlob(
+                flexOutboundPath,
+                new FileInputStream("src/test/resources/no/rutebanken/marduk/routes/file/beans/netex_with_two_files.zip"));
+
+        AdviceWith.adviceWith(context, "antu-netex-validation-complete", a -> {
+            a.interceptSendToEndpoint("direct:copyExternalBlobInBucket")
+                    .skipSendToOriginalEndpoint()
+                    .to("mock:copyExternalBlobInBucket");
+            a.interceptSendToEndpoint("direct:updateStatus")
+                    .skipSendToOriginalEndpoint()
+                    .to("mock:updateStatus");
+        });
+
+        AdviceWith.adviceWith(context, "antu-merged-netex-post-validation", a -> {
+            a.interceptSendToEndpoint("direct:copyInternalBlobToValidationBucket")
+                    .skipSendToOriginalEndpoint()
+                    .to("mock:copyInternalBlobToValidationBucket");
+            a.weaveByToUri("google-pubsub:(.*):AntuNetexValidationQueue")
+                    .replace()
+                    .to("mock:antuNetexValidationQueueMerged");
+            a.interceptSendToEndpoint("direct:updateStatus")
+                    .skipSendToOriginalEndpoint()
+                    .to("mock:updateStatus");
+        });
+
+        AdviceWith.adviceWith(context, "publish-merged-dataset", a -> {
+            a.weaveByToUri("google-pubsub:(.*):Otp2GraphBuildQueue")
+                    .replace()
+                    .to("mock:otp2GraphBuildQueue");
+        });
+
+        AdviceWith.adviceWith(context, "netex-notify-export", a -> a
+                .weaveByToUri("google-pubsub:(.*):NetexExportNotificationQueue")
+                .replace()
+                .to("mock:netexExportNotificationQueue"));
+
+        AdviceWith.adviceWith(context, "start-damu-gtfs-export", a -> a
+                .weaveByToUri("google-pubsub:(.*):GtfsRouteDispatcherTopic")
+                .replace()
+                .to("mock:gtfsRouteDispatcherTopic"));
+
+        context.start();
+
+        antuNetexValidationQueueMergedMock.expectedMessageCount(1);
+        antuNetexValidationQueueMergedMock.setResultWaitTime(30000);
+        otp2GraphBuildQueueMock.expectedMessageCount(0);
+        otp2GraphBuildQueueMock.setResultWaitTime(5000);
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(VALIDATION_STAGE_HEADER, VALIDATION_STAGE_FLEX_POSTVALIDATION);
+        headers.put(VALIDATION_DATASET_FILE_HANDLE_HEADER, "any/source/file.zip");
+        headers.put(VALIDATION_CORRELATION_ID_HEADER, "flex-correlation-id-distinct-from-ordinary");
+        headers.put(DATASET_REFERENTIAL, TestConstants.CHOUETTE_REFERENTIAL_RB_RUT);
+        sendBodyAndHeadersToPubSub(importTemplate, STATUS_VALIDATION_OK, headers);
+
+        antuNetexValidationQueueMergedMock.assertIsSatisfied();
+        otp2GraphBuildQueueMock.assertIsSatisfied();
+
+        Exchange captured = antuNetexValidationQueueMergedMock.getReceivedExchanges().getFirst();
+        assertEquals(VALIDATION_STAGE_EXPORT_MERGED_POSTVALIDATION,
+                captured.getIn().getHeader(VALIDATION_STAGE_HEADER));
     }
 }


### PR DESCRIPTION
Fixes a regression in the experimental import that could cause flexible data imports not merging with the latest timetable export. This only happened when importing the flexible datasets alone. The error was caused due to the latest exported timetable dataset for that codespace being placed at a path with a correlationId, which would differ from a correlationId used during flexible imports. The fix involves placing the timetable dataset on a fixed path, and using this as a fallback when the two correlationIds are not the same.