### PR TITLE
Order servicelinker LINKING status by emit time, not processing time

### DIFF
--- a/src/main/java/no/rutebanken/marduk/Constants.java
+++ b/src/main/java/no/rutebanken/marduk/Constants.java
@@ -169,6 +169,9 @@ public final class Constants {
     public static final String LINKING_NETEX_FILE_STATUS_FAILED = "FAILED";
     public static final String LINKED_NETEX_FILE_PATH_HEADER = "LinkedNetexFilePath";
     public static final String LINKING_ERROR_CODE_HEADER = "LinkingFailureReason";
+    // ISO-8601 instant stamped by servicelinker when it emitted the status, so the JobEvent
+    // event time reflects emit order even if Pub/Sub delivers STARTED/SUCCESS out of order.
+    public static final String LINKING_STATUS_EVENT_TIME_HEADER = "LinkingStatusEventTime";
     public static final String SERVICE_LINK_MODES_HEADER = "ServiceLinkModes";
 
     public static final String IMPORT_TYPE = "ImportType";

--- a/src/main/java/no/rutebanken/marduk/routes/experimental/ServicelinkerEnrichmentStatusRouteBuilder.java
+++ b/src/main/java/no/rutebanken/marduk/routes/experimental/ServicelinkerEnrichmentStatusRouteBuilder.java
@@ -3,9 +3,15 @@ package no.rutebanken.marduk.routes.experimental;
 import no.rutebanken.marduk.Constants;
 import no.rutebanken.marduk.routes.BaseRouteBuilder;
 import no.rutebanken.marduk.routes.status.JobEvent;
+import org.apache.camel.Exchange;
 import org.apache.camel.LoggingLevel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
 
 import static no.rutebanken.marduk.Constants.*;
 
@@ -24,6 +30,8 @@ import static no.rutebanken.marduk.Constants.*;
  */
 @Component
 public class ServicelinkerEnrichmentStatusRouteBuilder extends BaseRouteBuilder {
+
+    private static final Logger logger = LoggerFactory.getLogger(ServicelinkerEnrichmentStatusRouteBuilder.class);
 
     private final ExperimentalImportHelpers experimentalImportHelpers;
     private final boolean linkingEnabled;
@@ -69,17 +77,17 @@ public class ServicelinkerEnrichmentStatusRouteBuilder extends BaseRouteBuilder 
                 .when(header(Constants.LINKING_NETEX_FILE_STATUS_HEADER).isEqualTo(Constants.LINKING_NETEX_FILE_STATUS_SUCCEEDED))
                     .log(LoggingLevel.INFO, correlation() + "Received notification that Servicelinker enrichment has succeeded. File location: ${header." + Constants.LINKED_NETEX_FILE_PATH_HEADER + "}")
                     .to("direct:copyEnrichedDatasetToInternalBucket")
-                    .process(e -> JobEvent.providerJobBuilder(e).timetableAction(JobEvent.TimetableAction.LINKING).state(JobEvent.State.OK).build())
+                    .process(e -> JobEvent.providerJobBuilder(e).timetableAction(JobEvent.TimetableAction.LINKING).state(JobEvent.State.OK).eventTime(linkingStatusEventTime(e)).build())
                 .endChoice()
                 .when(header(Constants.LINKING_NETEX_FILE_STATUS_HEADER).isEqualTo(Constants.LINKING_NETEX_FILE_STATUS_STARTED))
                     .log(LoggingLevel.INFO, correlation() + "Received notification that Servicelinker enrichment has started.")
-                    .process(e -> JobEvent.providerJobBuilder(e).timetableAction(JobEvent.TimetableAction.LINKING).state(JobEvent.State.STARTED).build())
+                    .process(e -> JobEvent.providerJobBuilder(e).timetableAction(JobEvent.TimetableAction.LINKING).state(JobEvent.State.STARTED).eventTime(linkingStatusEventTime(e)).build())
                     .to("direct:updateStatus")
                     .stop()
                 .endChoice()
                 .when(header(Constants.LINKING_NETEX_FILE_STATUS_HEADER).isEqualTo(Constants.LINKING_NETEX_FILE_STATUS_FAILED))
                     .log(LoggingLevel.WARN, correlation() + "Received notification that Servicelinker enrichment has failed. Continuing with original file.")
-                    .process(e -> JobEvent.providerJobBuilder(e).timetableAction(JobEvent.TimetableAction.LINKING).state(JobEvent.State.FAILED).errorCode(e.getIn().getHeader(LINKING_ERROR_CODE_HEADER, String.class)).build())
+                    .process(e -> JobEvent.providerJobBuilder(e).timetableAction(JobEvent.TimetableAction.LINKING).state(JobEvent.State.FAILED).errorCode(e.getIn().getHeader(LINKING_ERROR_CODE_HEADER, String.class)).eventTime(linkingStatusEventTime(e)).build())
                 .endChoice()
                 .otherwise()
                     .log(LoggingLevel.ERROR, correlation() + "Received notification with unknown Servicelinker linking status: ${header." + Constants.LINKING_NETEX_FILE_STATUS_HEADER + "}")
@@ -99,5 +107,24 @@ public class ServicelinkerEnrichmentStatusRouteBuilder extends BaseRouteBuilder 
                 .end()
                 .routeId("copy-enriched-dataset-to-internal-bucket-route");
 
+    }
+
+    /**
+     * Servicelinker stamps each status message with the instant it emitted the status.
+     * Using that as the JobEvent event time keeps STARTED ordered before SUCCESS even when
+     * Pub/Sub delivers the two messages out of order. Falls back to null (i.e. now()) when the
+     * header is missing or unparseable, e.g. messages from an older servicelinker.
+     */
+    private static Instant linkingStatusEventTime(Exchange exchange) {
+        String value = exchange.getIn().getHeader(LINKING_STATUS_EVENT_TIME_HEADER, String.class);
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Instant.parse(value);
+        } catch (DateTimeParseException e) {
+            logger.warn("Could not parse {} header value '{}', falling back to receive time", LINKING_STATUS_EVENT_TIME_HEADER, value);
+            return null;
+        }
     }
 }

--- a/src/main/java/no/rutebanken/marduk/routes/status/JobEvent.java
+++ b/src/main/java/no/rutebanken/marduk/routes/status/JobEvent.java
@@ -294,7 +294,20 @@ public class JobEvent {
 
         protected final JobEvent jobEvent = new JobEvent();
 
+        private Instant eventTime;
+
         private Builder() {
+        }
+
+        /**
+         * Override the event time. When set, build() uses this instead of Instant.now().
+         * Used for events relayed from another service (e.g. servicelinker), so the event
+         * time reflects when the source emitted the status rather than when this service
+         * happened to process the (possibly reordered) message.
+         */
+        public Builder eventTime(Instant eventTime) {
+            this.eventTime = eventTime;
+            return this;
         }
 
         public Builder jobDomain(JobDomain jobDomain) {
@@ -381,7 +394,7 @@ public class JobEvent {
             if (jobEvent.domain == null) {
                 throw new IllegalArgumentException("No job domain");
             }
-            jobEvent.eventTime = Instant.now();
+            jobEvent.eventTime = eventTime != null ? eventTime : Instant.now();
             return jobEvent;
         }
     }

--- a/src/test/java/no/rutebanken/marduk/routes/experimental/ServicelinkerEnrichmentStatusRouteBuilderTest.java
+++ b/src/test/java/no/rutebanken/marduk/routes/experimental/ServicelinkerEnrichmentStatusRouteBuilderTest.java
@@ -2,6 +2,7 @@ package no.rutebanken.marduk.routes.experimental;
 
 import no.rutebanken.marduk.Constants;
 import no.rutebanken.marduk.MardukRouteBuilderIntegrationTestBase;
+import no.rutebanken.marduk.routes.status.JobEvent;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.context.TestPropertySource;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -132,5 +134,108 @@ class ServicelinkerEnrichmentStatusRouteBuilderTest extends MardukRouteBuilderIn
             receivedMessages.stream().anyMatch(body -> body.contains("\"action\":\"LINKING\"") && body.contains("\"state\":\"FAILED\"")),
             "Expected status update with action=LINKING and state=FAILED"
         );
+    }
+
+    @Test
+    void testStartedStatusStopsAndPropagatesEmitTime() throws Exception {
+        interceptRoutes();
+
+        context.start();
+
+        // STARTED branch updates status then stops — it must not copy the file or continue to Ashur
+        updateStatusEndpoint.expectedMessageCount(1);
+        copyBlobFromAnotherBucketToInternalEndpoint.expectedMessageCount(0);
+        ashurFilterEndpoint.expectedMessageCount(0);
+
+        Instant emitTime = Instant.parse("2026-06-03T10:15:30Z");
+
+        sendBodyAndHeadersToPubSub(statusTemplate, null, Map.of(
+            Constants.LINKING_NETEX_FILE_STATUS_HEADER, Constants.LINKING_NETEX_FILE_STATUS_STARTED,
+            Constants.LINKING_STATUS_EVENT_TIME_HEADER, emitTime.toString(),
+            Constants.DATASET_REFERENTIAL, "tst",
+            Constants.PROVIDER_ID, "0",
+            Constants.CORRELATION_ID, "someCorrelationId"
+        ));
+
+        updateStatusEndpoint.assertIsSatisfied();
+        copyBlobFromAnotherBucketToInternalEndpoint.assertIsSatisfied();
+        ashurFilterEndpoint.assertIsSatisfied();
+
+        JobEvent event = relayedJobEvent();
+        assertEquals("LINKING", event.getAction());
+        assertEquals(JobEvent.State.STARTED, event.getState());
+        assertEquals(emitTime, event.getEventTime(), "Servicelinker emit time must be propagated to the JobEvent");
+    }
+
+    @Test
+    void testEmitTimePropagatedOnSuccess() throws Exception {
+        interceptRoutes();
+
+        context.start();
+
+        updateStatusEndpoint.expectedMessageCount(1);
+
+        Instant emitTime = Instant.parse("2026-06-03T10:20:45Z");
+
+        sendBodyAndHeadersToPubSub(statusTemplate, null, Map.of(
+            Constants.LINKING_NETEX_FILE_STATUS_HEADER, Constants.LINKING_NETEX_FILE_STATUS_SUCCEEDED,
+            Constants.LINKED_NETEX_FILE_PATH_HEADER, "servicelinker/tst/some-uuid/tst-aggregated-netex.zip",
+            Constants.LINKING_STATUS_EVENT_TIME_HEADER, emitTime.toString(),
+            Constants.FILE_HANDLE, "chouette/netex-before-validation/tst-export.zip",
+            Constants.DATASET_REFERENTIAL, "tst",
+            Constants.PROVIDER_ID, "0",
+            Constants.CORRELATION_ID, "someCorrelationId"
+        ));
+
+        updateStatusEndpoint.assertIsSatisfied();
+
+        JobEvent event = relayedJobEvent();
+        assertEquals(JobEvent.State.OK, event.getState());
+        assertEquals(emitTime, event.getEventTime(), "Servicelinker emit time must be propagated to the JobEvent");
+    }
+
+    @Test
+    void testMissingEmitTimeFallsBackToProcessingTime() throws Exception {
+        assertFallbackToProcessingTime(null);
+    }
+
+    @Test
+    void testUnparseableEmitTimeFallsBackToProcessingTime() throws Exception {
+        assertFallbackToProcessingTime("not-a-timestamp");
+    }
+
+    private void assertFallbackToProcessingTime(String emitTimeHeader) throws Exception {
+        interceptRoutes();
+
+        context.start();
+
+        updateStatusEndpoint.expectedMessageCount(1);
+
+        java.util.Map<String, String> headers = new java.util.HashMap<>(Map.of(
+            Constants.LINKING_NETEX_FILE_STATUS_HEADER, Constants.LINKING_NETEX_FILE_STATUS_SUCCEEDED,
+            Constants.LINKED_NETEX_FILE_PATH_HEADER, "servicelinker/tst/some-uuid/tst-aggregated-netex.zip",
+            Constants.FILE_HANDLE, "chouette/netex-before-validation/tst-export.zip",
+            Constants.DATASET_REFERENTIAL, "tst",
+            Constants.PROVIDER_ID, "0",
+            Constants.CORRELATION_ID, "someCorrelationId"
+        ));
+        if (emitTimeHeader != null) {
+            headers.put(Constants.LINKING_STATUS_EVENT_TIME_HEADER, emitTimeHeader);
+        }
+
+        Instant before = Instant.now();
+        sendBodyAndHeadersToPubSub(statusTemplate, null, headers);
+        updateStatusEndpoint.assertIsSatisfied();
+        Instant after = Instant.now();
+
+        JobEvent event = relayedJobEvent();
+        assertEquals(JobEvent.State.OK, event.getState());
+        assertTrue(!event.getEventTime().isBefore(before) && !event.getEventTime().isAfter(after),
+            "Expected event time to fall back to processing time (~now), but was " + event.getEventTime());
+    }
+
+    private JobEvent relayedJobEvent() {
+        String body = updateStatusEndpoint.getReceivedExchanges().getFirst().getIn().getBody(String.class);
+        return JobEvent.fromString(body);
     }
 }

--- a/src/test/java/no/rutebanken/marduk/routes/status/JobEventTest.java
+++ b/src/test/java/no/rutebanken/marduk/routes/status/JobEventTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ *
+ */
+
+package no.rutebanken.marduk.routes.status;
+
+import no.rutebanken.marduk.Constants;
+import org.apache.camel.Exchange;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JobEventTest {
+
+    private static Exchange exchange() {
+        Exchange exchange = new DefaultExchange(new DefaultCamelContext());
+        exchange.getIn().setHeader(Constants.PROVIDER_ID, "1");
+        exchange.getIn().setHeader(Constants.CORRELATION_ID, "correlation");
+        return exchange;
+    }
+
+    /**
+     * When an explicit event time is supplied (e.g. the emit time relayed from servicelinker),
+     * build() must use it verbatim rather than overwriting it with the current time.
+     */
+    @Test
+    void explicitEventTimeIsUsed() {
+        Instant emitTime = Instant.parse("2026-06-03T10:15:30Z");
+
+        JobEvent event = JobEvent.providerJobBuilder(exchange())
+                .timetableAction(JobEvent.TimetableAction.LINKING)
+                .state(JobEvent.State.OK)
+                .eventTime(emitTime)
+                .build();
+
+        assertEquals(emitTime, event.getEventTime());
+    }
+
+    /**
+     * When no event time is supplied (e.g. a message from an older servicelinker without the
+     * emit-time header), build() must fall back to the current time so the field is never null.
+     */
+    @Test
+    void eventTimeDefaultsToNowWhenNotSet() {
+        Instant before = Instant.now();
+
+        JobEvent event = JobEvent.providerJobBuilder(exchange())
+                .timetableAction(JobEvent.TimetableAction.LINKING)
+                .state(JobEvent.State.STARTED)
+                .build();
+
+        Instant after = Instant.now();
+
+        assertNotNull(event.getEventTime());
+        assertTrue(!event.getEventTime().isBefore(before) && !event.getEventTime().isAfter(after),
+                "Expected event time to default to ~now, but was " + event.getEventTime());
+    }
+
+    /**
+     * A null event time must also trigger the fallback (the route passes null when the emit-time
+     * header is missing or unparseable).
+     */
+    @Test
+    void nullEventTimeFallsBackToNow() {
+        Instant before = Instant.now();
+
+        JobEvent event = JobEvent.providerJobBuilder(exchange())
+                .timetableAction(JobEvent.TimetableAction.LINKING)
+                .state(JobEvent.State.OK)
+                .eventTime(null)
+                .build();
+
+        assertNotNull(event.getEventTime());
+        assertTrue(!event.getEventTime().isBefore(before), "Expected fallback to now(), but was " + event.getEventTime());
+    }
+}


### PR DESCRIPTION
JobEvent.build() stamped eventTime = now() at processing time, so when Pub/Sub delivered servicelinker's STARTED/SUCCESS out of order the recorded times inverted and the UI showed LINKING stuck at "Started". Carry the relayed LinkingStatusEventTime into the JobEvent instead, falling back to now() when the header is absent (older servicelinker).