### PR TITLE
Upgrade Apache Camel to 4.18.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     </scm>
     <properties>
         <java.version>21</java.version>
-        <camel.version>4.4.5</camel.version>
+        <camel.version>4.18.2</camel.version>
         <entur.helpers.version>5.50.0</entur.helpers.version>
         <commons-io.version>2.21.0</commons-io.version>
         <commons-csv.version>1.14.1</commons-csv.version>
@@ -173,9 +173,20 @@
             <groupId>org.apache.camel.springboot</groupId>
             <artifactId>camel-kubernetes-starter</artifactId>
         </dependency>
+        <!-- Cluster services back the master: endpoint used by BaseRouteBuilder.singletonFrom()
+             (kubernetes leader election in prod, file-lock locally). Camel 4.18 no longer pulls
+             these in transitively; without them every pod runs singleton routes. -->
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-kubernetes-cluster-service-starter</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.camel.springboot</groupId>
             <artifactId>camel-file-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-file-cluster-service-starter</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.springboot</groupId>
@@ -275,6 +286,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-test-spring-junit5</artifactId>
+            <version>${camel.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/no/rutebanken/marduk/config/AuthorizationConfig.java
+++ b/src/main/java/no/rutebanken/marduk/config/AuthorizationConfig.java
@@ -16,6 +16,7 @@
 
 package no.rutebanken.marduk.config;
 
+import jakarta.servlet.http.HttpServletRequest;
 import no.rutebanken.marduk.repository.ProviderRepository;
 import no.rutebanken.marduk.security.DefaultMardukAuthorizationService;
 import no.rutebanken.marduk.security.MardukAuthorizationService;
@@ -28,10 +29,12 @@ import org.rutebanken.helper.organisation.authorization.AuthorizationService;
 import org.rutebanken.helper.organisation.authorization.DefaultAuthorizationService;
 import org.rutebanken.helper.organisation.authorization.FullAccessAuthorizationService;
 import org.rutebanken.helper.organisation.user.UserInfoExtractor;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManagerResolver;
 import org.springframework.web.reactive.function.client.WebClient;
 
 /**
@@ -113,8 +116,10 @@ public class AuthorizationConfig {
 
 
     @Bean
-    public MardukAuthorizationService mardukAuthorizationService(AuthorizationService<Long> authorizationService) {
-        return new DefaultMardukAuthorizationService(authorizationService);
+    public MardukAuthorizationService mardukAuthorizationService(
+            AuthorizationService<Long> authorizationService,
+            ObjectProvider<AuthenticationManagerResolver<HttpServletRequest>> resolverProvider) {
+        return new DefaultMardukAuthorizationService(authorizationService, resolverProvider.getIfAvailable());
     }
 
 }

--- a/src/main/java/no/rutebanken/marduk/config/CamelConfig.java
+++ b/src/main/java/no/rutebanken/marduk/config/CamelConfig.java
@@ -19,7 +19,11 @@ package no.rutebanken.marduk.config;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import no.rutebanken.marduk.routes.aggregation.IdleRouteAggregationMonitor;
 import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
 import org.apache.camel.builder.ThreadPoolBuilder;
+import org.apache.camel.component.google.pubsub.GooglePubsubComponent;
+import org.apache.camel.component.google.pubsub.GooglePubsubHeaderFilterStrategy;
+import org.apache.camel.spi.ComponentCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -76,5 +80,28 @@ public class CamelConfig {
         return new IdleRouteAggregationMonitor(camelContext);
     }
 
+    /**
+     * Restricts outbound Google PubSub message attributes to the explicit attribute map built by
+     * {@link no.rutebanken.marduk.routes.BaseRouteBuilder}.
+     *
+     * <p>Since Camel 4.x the PubSub producer also copies every non-filtered Camel header into the
+     * published message attributes, which would leak internal headers such as {@code breadcrumbId}.
+     * This strategy filters out all Camel headers when producing, so only the curated attribute map
+     * is published. Inbound filtering keeps the component default behaviour.
+     */
+    @Bean
+    ComponentCustomizer googlePubsubHeaderFilterCustomizer() {
+        return ComponentCustomizer
+                .builder(GooglePubsubComponent.class)
+                .build(component -> component.setHeaderFilterStrategy(new OutboundFilteringHeaderFilterStrategy()));
+    }
+
+    static class OutboundFilteringHeaderFilterStrategy extends GooglePubsubHeaderFilterStrategy {
+
+        @Override
+        public boolean applyFilterToCamelHeaders(String headerName, Object headerValue, Exchange exchange) {
+            return true;
+        }
+    }
 
 }

--- a/src/main/java/no/rutebanken/marduk/rest/AdminRestRouteBuilder.java
+++ b/src/main/java/no/rutebanken/marduk/rest/AdminRestRouteBuilder.java
@@ -786,7 +786,7 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
 
         from("direct:authorizeAdminRequest")
                 .doTry()
-                .process(e -> mardukAuthorizationService.verifyAdministratorPrivileges(e))
+                .process(mardukAuthorizationService::verifyAdministratorPrivileges)
                 .to("direct:setUsername")
                 .routeId("admin-authorize-admin-request");
 

--- a/src/main/java/no/rutebanken/marduk/rest/AdminRestRouteBuilder.java
+++ b/src/main/java/no/rutebanken/marduk/rest/AdminRestRouteBuilder.java
@@ -102,6 +102,10 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
         restConfiguration()
                 .component("platform-http")
                 .contextPath("/services")
+                // Keep direct: target routes standalone so several REST routes can share the same
+                // direct endpoint (e.g. /files and /flex/files both reach direct:adminDatasetUploadFile).
+                // Inlining (the Camel default) would absorb the consumer into one REST route.
+                .inlineRoutes(false)
                 .bindingMode(RestBindingMode.json)
                 .apiContextPath("/openapi.yaml")
                 .apiProperty("api.title", "Timetable Admin API").apiProperty("api.version", "1.0");
@@ -129,14 +133,12 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
 
                 .post("/validate/prevalidation")
                 .description("Triggers the prevalidation process for all providers in Chouette")
-                .consumes(PLAIN)
                 .produces(PLAIN)
                 .responseMessage().code(200).message("Command accepted").endResponseMessage()
                 .to("direct:adminTriggerPrevalidationForAllProviders")
 
                 .post("/validate/level2")
                 .description("Triggers the validate->export process for all level2 providers in Chouette")
-                .consumes(PLAIN)
                 .produces(PLAIN)
                 .responseMessage().code(200).message("Command accepted").endResponseMessage()
                 .to("direct:adminChouetteValidateLevel2AllProviders")
@@ -158,7 +160,6 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
                 .allowableValues("importer", "exporter", "validator")
                 .endParam()
                 .outType(ProviderAndJobs[].class)
-                .consumes(PLAIN)
                 .produces(JSON)
                 .responseMessage().code(200).endResponseMessage()
                 .responseMessage().code(500).message("Internal error").endResponseMessage()
@@ -199,7 +200,6 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
                 .description("Optional filter to clean only level 1, level 2 or all spaces (no parameter value)")
                 .allowableValues("all", "level1", "level2")
                 .endParam()
-                .consumes(PLAIN)
                 .produces(PLAIN)
                 .responseMessage().code(200).message("Command accepted").endResponseMessage()
                 .responseMessage().code(500).message("Internal error - check filter").endResponseMessage()
@@ -207,7 +207,6 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
 
                 .post("/stop_places/clean")
                 .description("Triggers the cleaning of ALL stop places in Chouette")
-                .consumes(PLAIN)
                 .produces(PLAIN)
                 .responseMessage().code(200).message("Command accepted").endResponseMessage()
                 .responseMessage().code(500).message("Internal error - check filter").endResponseMessage()
@@ -228,7 +227,6 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
                 .allowableValues("all", "level1", "level2")
                 .endParam()
                 .bindingMode(RestBindingMode.off)
-                .consumes(PLAIN)
                 .produces(JSON)
                 .responseMessage().code(200).endResponseMessage()
                 .responseMessage().code(500).message("Internal error").endResponseMessage()
@@ -237,7 +235,6 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
                 .post("/line_statistics/refresh")
                 .description("Recalculate stats about data in chouette for all providers")
                 .bindingMode(RestBindingMode.off)
-                .consumes(PLAIN)
                 .produces(PLAIN)
                 .responseMessage().code(200).endResponseMessage()
                 .responseMessage().code(500).message("Internal error").endResponseMessage()
@@ -246,7 +243,6 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
                 .get("/export/files")
                 .description("List files containing exported time table data and graphs")
                 .outType(BlobStoreFiles.class)
-                .consumes(PLAIN)
                 .produces(JSON)
                 .responseMessage().code(200).endResponseMessage()
                 .responseMessage().code(500).message("Internal error").endResponseMessage()
@@ -254,7 +250,6 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
 
                 .post("/export/gtfs/merged")
                 .description("Prepare and upload merged GTFS export")
-                .consumes(PLAIN)
                 .produces(PLAIN)
                 .responseMessage().code(200).endResponseMessage()
                 .responseMessage().code(500).message("Internal error").endResponseMessage()
@@ -262,14 +257,12 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
 
                 .post("routing_graph/build_base")
                 .description("Triggers building of the OTP base graph using map data (osm + height)")
-                .consumes(PLAIN)
                 .produces(PLAIN)
                 .responseMessage().code(200).message("Command accepted").endResponseMessage()
                 .to("direct:adminBuildBaseGraph")
 
                 .post("routing_graph/build")
                 .description("Triggers building of the OTP graph using existing NeTEx and and a pre-prepared base graph with map data")
-                .consumes(PLAIN)
                 .produces(PLAIN)
                 .responseMessage().code(200).message("Command accepted").endResponseMessage()
                 .to("direct:adminBuildGraphNetex")
@@ -277,7 +270,6 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
                 .post("routing_graph/build_candidate/{graphType}")
                 .description("Triggers graph building for a candidate OTP version")
                 .param().name("graphType").type(RestParamType.path).description("Type of graph").dataType(OPENAPI_DATA_TYPE_STRING).endParam()
-                .consumes(PLAIN)
                 .produces(PLAIN)
                 .responseMessage().code(200).message("Command accepted").endResponseMessage()
                 .to("direct:adminBuildGraphCandidate")
@@ -285,7 +277,6 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
                 .get("routing_graph/graphs")
                 .description("List latest generated OTP2 graphs")
                 .outType(OtpGraphsInfo[].class)
-                .consumes(PLAIN)
                 .produces(JSON)
                 .responseMessage().code(200).endResponseMessage()
                 .to("direct:adminListGraphs")
@@ -305,7 +296,6 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
                 .description("Download NeTEx dataset with blocks")
                 .deprecated()
                 .param().name("codespace").type(RestParamType.path).description("Codespace of the organization producing the NeTEx dataset with blocks").dataType(OPENAPI_DATA_TYPE_STRING).endParam()
-                .consumes(PLAIN)
                 .produces(X_OCTET_STREAM)
                 .responseMessage().code(200).endResponseMessage()
                 .responseMessage().code(500).message("Invalid codespace").endResponseMessage()
@@ -343,7 +333,6 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
                 .description("List files available for reimport")
                 .param().name("providerId").type(RestParamType.path).description("Provider id as obtained from the nabu service").dataType(OPENAPI_DATA_TYPE_INTEGER).endParam()
                 .outType(BlobStoreFiles.class)
-                .consumes(PLAIN)
                 .produces(JSON)
                 .responseMessage().code(200).endResponseMessage()
                 .responseMessage().code(500).message("Invalid providerId").endResponseMessage()
@@ -373,7 +362,6 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
                 .description("Download file for reimport")
                 .param().name("providerId").type(RestParamType.path).description("Provider id as obtained from the nabu service").dataType(OPENAPI_DATA_TYPE_INTEGER).endParam()
                 .param().name("fileName").type(RestParamType.path).description("Name of file to fetch").dataType(OPENAPI_DATA_TYPE_STRING).endParam()
-                .consumes(PLAIN)
                 .produces(X_OCTET_STREAM)
                 .responseMessage().code(200).endResponseMessage()
                 .responseMessage().code(500).message("Invalid fileName").endResponseMessage()
@@ -383,7 +371,6 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
                 .description("List stats about data in chouette for a given provider")
                 .param().name("providerId").type(RestParamType.path).description("Provider id as obtained from the nabu service").dataType(OPENAPI_DATA_TYPE_INTEGER).endParam()
                 .bindingMode(RestBindingMode.off)
-                .consumes(PLAIN)
                 .produces(JSON)
                 .responseMessage().code(200).endResponseMessage()
                 .responseMessage().code(500).message("Invalid providerId").endResponseMessage()
@@ -407,7 +394,6 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
                 .allowableValues("importer", "exporter", "validator")
                 .endParam()
                 .outType(JobResponse[].class)
-                .consumes(PLAIN)
                 .produces(JSON)
                 .responseMessage().code(200).endResponseMessage()
                 .responseMessage().code(500).message("Invalid providerId").endResponseMessage()
@@ -416,7 +402,6 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
                 .delete("/jobs")
                 .description("Cancel all Chouette jobs for a given provider")
                 .param().name("providerId").type(RestParamType.path).description("Provider id as obtained from the nabu service").dataType(OPENAPI_DATA_TYPE_INTEGER).endParam()
-                .consumes(PLAIN)
                 .produces(PLAIN)
                 .responseMessage().code(200).message("Job deleted").endResponseMessage()
                 .responseMessage().code(500).message("Invalid jobId").endResponseMessage()
@@ -426,7 +411,6 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
                 .description("Cancel a Chouette job for a given provider")
                 .param().name("providerId").type(RestParamType.path).description("Provider id as obtained from the nabu service").dataType(OPENAPI_DATA_TYPE_INTEGER).endParam()
                 .param().name("jobId").type(RestParamType.path).description("Job id as returned in any of the /jobs GET calls").dataType(OPENAPI_DATA_TYPE_INTEGER).endParam()
-                .consumes(PLAIN)
                 .produces(PLAIN)
                 .responseMessage().code(200).message("Job deleted").endResponseMessage()
                 .responseMessage().code(500).message("Invalid jobId").endResponseMessage()
@@ -435,7 +419,6 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
                 .post("/export")
                 .description("Triggers the export process in Chouette. Note that NO validation is performed before export, and that the data must be guaranteed to be error free")
                 .param().name("providerId").type(RestParamType.path).description("Provider id as obtained from the nabu service").dataType(OPENAPI_DATA_TYPE_INTEGER).endParam()
-                .consumes(PLAIN)
                 .produces(PLAIN)
                 .responseMessage().code(200).message("Command accepted").endResponseMessage()
                 .to("direct:adminChouetteExport")
@@ -443,7 +426,6 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
                 .post("/validate")
                 .description("Triggers the validate->export process in Chouette")
                 .param().name("providerId").type(RestParamType.path).description("Provider id as obtained from the nabu service").dataType(OPENAPI_DATA_TYPE_INTEGER).endParam()
-                .consumes(PLAIN)
                 .produces(PLAIN)
                 .responseMessage().code(200).message("Command accepted").endResponseMessage()
                 .to("direct:adminChouetteValidate")
@@ -451,7 +433,6 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
                 .post("/clean")
                 .description("Triggers the clean dataspace process in Chouette. Only timetable data are deleted, not job data (imports, exports, validations)")
                 .param().name("providerId").type(RestParamType.path).description("Provider id as obtained from the nabu service").dataType(OPENAPI_DATA_TYPE_INTEGER).endParam()
-                .consumes(PLAIN)
                 .produces(PLAIN)
                 .responseMessage().code(200).message("Command accepted").endResponseMessage()
                 .to("direct:adminChouetteClean")
@@ -459,7 +440,6 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
                 .post("/transfer")
                 .description("Triggers transfer of data from one dataspace to the next")
                 .param().name("providerId").type(RestParamType.path).description("Provider id as obtained from the nabu service").dataType(OPENAPI_DATA_TYPE_INTEGER).endParam()
-                .consumes(PLAIN)
                 .produces(PLAIN)
                 .responseMessage().code(200).message("Command accepted").endResponseMessage()
                 .to("direct:adminChouetteTransfer");
@@ -467,7 +447,6 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
         rest("/map_admin")
                 .post("/download")
                 .description("Triggers downloading of the latest OSM data")
-                .consumes(PLAIN)
                 .produces(PLAIN)
                 .responseMessage().code(200).message("Command accepted").endResponseMessage()
                 .to("direct:adminFetchOsm");
@@ -641,10 +620,12 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
                 .routeId("admin-chouette-graph-list");
 
         from("direct:adminDatasetImport")
-                .process(this::removeHttpHeaders)
                 .setHeader(PROVIDER_ID, header("providerId"))
                 .to("direct:authorizeAdminRequest")
                 .to("direct:validateProvider")
+                // Strip HTTP headers only after authorization so the platform-http worker thread can
+                // rebuild the Spring Security context from the Authorization header (Camel 4.x async).
+                .process(this::removeHttpHeaders)
                 .split(method(ImportFilesSplitter.class, "splitFiles"))
 
                 .process(e -> {
@@ -663,6 +644,10 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
                 .setBody(constant(""))
 
                 .to(ExchangePattern.InOnly, "google-pubsub:{{marduk.pubsub.project.id}}:ProcessFileQueue")
+                .end()
+                // Replace the split input list left as the body by the splitter with an empty
+                // response body that platform-http can write back to the client.
+                .setBody(constant(""))
                 .routeId("admin-chouette-import");
 
         from("direct:adminFlexImport")
@@ -791,27 +776,30 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
 
 
         from("direct:validateProvider")
-                .validate(e -> getProviderRepository().getProvider(e.getIn().getHeader(PROVIDER_ID, Long.class)) != null)
-                .predicateExceptionFactory((exchange, predicate, nodeId) -> new NotFoundException("Unknown provider id"))
+                .process(e -> {
+                    if (getProviderRepository().getProvider(e.getIn().getHeader(PROVIDER_ID, Long.class)) == null) {
+                        throw new NotFoundException("Unknown provider id");
+                    }
+                })
                 .id("validate-provider")
                 .routeId("admin-validate-provider");
 
         from("direct:authorizeAdminRequest")
                 .doTry()
-                .process(e -> mardukAuthorizationService.verifyAdministratorPrivileges())
+                .process(e -> mardukAuthorizationService.verifyAdministratorPrivileges(e))
                 .to("direct:setUsername")
                 .routeId("admin-authorize-admin-request");
 
         from("direct:authorizeEditorRequest")
                 .doTry()
-                .process(e -> mardukAuthorizationService.verifyRouteDataEditorPrivileges(e.getIn().getHeader(PROVIDER_ID, Long.class)))
+                .process(e -> mardukAuthorizationService.verifyRouteDataEditorPrivileges(e.getIn().getHeader(PROVIDER_ID, Long.class), e))
                 .to("direct:setUsername")
                 .routeId("admin-authorize-editor-request");
 
         from("direct:authorizeBlocksDownloadRequest")
                 .doTry()
                 .log(LoggingLevel.INFO, "Authorizing NeTEx blocks download for provider ${header." + CHOUETTE_REFERENTIAL + "} ")
-                .process(e -> mardukAuthorizationService.verifyBlockViewerPrivileges(e.getIn().getHeader(PROVIDER_ID, Long.class)))
+                .process(e -> mardukAuthorizationService.verifyBlockViewerPrivileges(e.getIn().getHeader(PROVIDER_ID, Long.class), e))
                 .to("direct:setUsername")
                 .routeId("admin-authorize-blocks-download-request");
 
@@ -877,8 +865,11 @@ public class AdminRestRouteBuilder extends BaseRouteBuilder {
                 .routeId("admin-external-download-private_dataset");
 
         from("direct:validateReferential")
-                .validate(e -> getProviderRepository().getProviderId(e.getIn().getHeader(CHOUETTE_REFERENTIAL, String.class)) != null)
-                .predicateExceptionFactory((exchange, predicate, nodeId) -> new NotFoundException("Unknown chouette referential"))
+                .process(e -> {
+                    if (getProviderRepository().getProviderId(e.getIn().getHeader(CHOUETTE_REFERENTIAL, String.class)) == null) {
+                        throw new NotFoundException("Unknown chouette referential");
+                    }
+                })
                 .id("validate-referential")
                 .routeId("admin-validate-referential");
 

--- a/src/main/java/no/rutebanken/marduk/routes/BaseRouteBuilder.java
+++ b/src/main/java/no/rutebanken/marduk/routes/BaseRouteBuilder.java
@@ -122,6 +122,7 @@ public abstract class BaseRouteBuilder extends RouteBuilder {
                     Map<String, String> pubSubAttributes = new HashMap<>();
                     exchange.getIn().getHeaders().entrySet().stream()
                             .filter(entry -> !entry.getKey().startsWith("Camel"))
+                            .filter(entry -> !entry.getKey().equals(Exchange.BREADCRUMB_ID))
                             .filter(entry -> Objects.toString(entry.getValue()).length() <= 1024)
                             .forEach(entry -> pubSubAttributes.put(entry.getKey(), Objects.toString(entry.getValue(), "")));
                     exchange.getIn().setHeader(GooglePubsubConstants.ATTRIBUTES, pubSubAttributes);

--- a/src/main/java/no/rutebanken/marduk/routes/BaseRouteBuilder.java
+++ b/src/main/java/no/rutebanken/marduk/routes/BaseRouteBuilder.java
@@ -48,6 +48,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
+import static org.apache.hc.core5.http.HttpHeaders.AUTHORIZATION;
+
 
 /**
  * Defines common route behavior.
@@ -123,6 +125,7 @@ public abstract class BaseRouteBuilder extends RouteBuilder {
                     exchange.getIn().getHeaders().entrySet().stream()
                             .filter(entry -> !entry.getKey().startsWith("Camel"))
                             .filter(entry -> !entry.getKey().equals(Exchange.BREADCRUMB_ID))
+                            .filter(entry -> !entry.getKey().equalsIgnoreCase(AUTHORIZATION))
                             .filter(entry -> Objects.toString(entry.getValue()).length() <= 1024)
                             .forEach(entry -> pubSubAttributes.put(entry.getKey(), Objects.toString(entry.getValue(), "")));
                     exchange.getIn().setHeader(GooglePubsubConstants.ATTRIBUTES, pubSubAttributes);
@@ -207,7 +210,7 @@ public abstract class BaseRouteBuilder extends RouteBuilder {
         // Remove Camel internal HTTP headers
         e.getIn().removeHeaders(Constants.CAMEL_ALL_HTTP_HEADERS);
         // Remove authorization HTTP header
-        e.getIn().removeHeader(org.apache.hc.core5.http.HttpHeaders.AUTHORIZATION);
+        e.getIn().removeHeader(AUTHORIZATION);
     }
 
     /**

--- a/src/main/java/no/rutebanken/marduk/routes/chouette/AntuNetexValidationStatusRouteBuilder.java
+++ b/src/main/java/no/rutebanken/marduk/routes/chouette/AntuNetexValidationStatusRouteBuilder.java
@@ -165,6 +165,9 @@ public class AntuNetexValidationStatusRouteBuilder extends AbstractChouetteRoute
 
         from("direct:antuNetexValidationComplete")
                 .log(LoggingLevel.INFO, getClass().getName(), correlation() + "Antu NeTEx validation complete for referential ${header." + DATASET_REFERENTIAL + "}")
+                // NOTE: every nested choice()/filter() inside a when() below is closed with .end() before
+                // .endChoice(). In Camel 4.x endChoice() pops only one level, so a missing .end() silently
+                // reattaches the following whens/otherwise to the inner block. Do not remove these .end() calls.
                 .choice()
 
                 .when(and(header(VALIDATION_STAGE_HEADER).isEqualTo(VALIDATION_STAGE_PREVALIDATION), experimentalImportHelpers::shouldRunExperimentalImport))
@@ -204,6 +207,7 @@ public class AntuNetexValidationStatusRouteBuilder extends AbstractChouetteRoute
                     .log(LoggingLevel.INFO, correlation() + "Posting " + FILE_HANDLE + " ${header." + FILE_HANDLE + "} and " + FILE_TYPE + " ${header." + FILE_TYPE + "} on chouette import queue.")
                     .to("google-pubsub:{{marduk.pubsub.project.id}}:ChouetteImportQueue")
                     .process(e -> JobEvent.providerJobBuilder(e).timetableAction(JobEvent.TimetableAction.PREVALIDATION).state(JobEvent.State.OK).build())
+                    .end()
                 .endChoice()
 
                 .when(and(header(VALIDATION_STAGE_HEADER).isEqualTo(VALIDATION_STAGE_EXPORT_NETEX_POSTVALIDATION), experimentalImportHelpers::shouldRunExperimentalImport))
@@ -224,6 +228,7 @@ public class AntuNetexValidationStatusRouteBuilder extends AbstractChouetteRoute
                         .to("google-pubsub:{{marduk.pubsub.project.id}}:ExportNetexBlocksQueue")
                     .otherwise()
                         .log(LoggingLevel.INFO, correlation() + "Skipping export of NetEx blocks to Ashur after post-validation because provider has blocks export disabled")
+                    .end()
                 .endChoice()
 
                 .when(and(header(VALIDATION_STAGE_HEADER).isEqualTo(VALIDATION_STAGE_EXPORT_NETEX_POSTVALIDATION), exchange -> !experimentalImportHelpers.shouldRunExperimentalImport(exchange)))
@@ -239,6 +244,7 @@ public class AntuNetexValidationStatusRouteBuilder extends AbstractChouetteRoute
                     .to("direct:copyInternalBlobInBucket")
                     .to("google-pubsub:{{marduk.pubsub.project.id}}:ChouetteMergeWithFlexibleLinesQueue")
                     .to("google-pubsub:{{marduk.pubsub.project.id}}:ChouetteExportNetexBlocksQueue")
+                    .end()
                 .endChoice()
 
                 .when(header(VALIDATION_STAGE_HEADER).isEqualTo(VALIDATION_STAGE_EXPORT_NETEX_BLOCKS_POSTVALIDATION))
@@ -246,6 +252,7 @@ public class AntuNetexValidationStatusRouteBuilder extends AbstractChouetteRoute
                 .filter(PredicateBuilder.not(simple("{{chouette.enablePostValidation:true}}")))
                 .setHeader(TARGET_FILE_HANDLE, simple(Constants.BLOBSTORE_PATH_NETEX_BLOCKS_EXPORT + "${header." + CHOUETTE_REFERENTIAL + "}-" + Constants.CURRENT_AGGREGATED_NETEX_FILENAME))
                 .to("direct:copyInternalBlobInBucket")
+                .end()
                 .endChoice()
 
                 .when(header(VALIDATION_STAGE_HEADER).isEqualTo(VALIDATION_STAGE_FLEX_POSTVALIDATION))

--- a/src/main/java/no/rutebanken/marduk/routes/chouette/ChouetteImportRouteBuilder.java
+++ b/src/main/java/no/rutebanken/marduk/routes/chouette/ChouetteImportRouteBuilder.java
@@ -197,6 +197,9 @@ public class ChouetteImportRouteBuilder extends AbstractChouetteRouteBuilder {
                 .log(LoggingLevel.ERROR, correlation() + "Something went wrong on import")
                 .process(e -> JobEvent.providerJobBuilder(e).timetableAction(TimetableAction.IMPORT).state(State.FAILED).build())
                 .end()
+                // Close the outer choice so the status update is sent for every branch (Camel 4.x no
+                // longer lets the trailing endChoice/end fall through to the parent choice automatically).
+                .end()
                 .to("direct:updateStatus")
                 .routeId("chouette-process-import-status");
 

--- a/src/main/java/no/rutebanken/marduk/routes/file/FileUploadRouteBuilder.java
+++ b/src/main/java/no/rutebanken/marduk/routes/file/FileUploadRouteBuilder.java
@@ -58,6 +58,10 @@ public class FileUploadRouteBuilder extends TransactionalBaseRouteBuilder {
                 .setHeader(FILE_HANDLE, simple("inbound/received/${header." + CHOUETTE_REFERENTIAL + "}/${header." + FILE_NAME + "}"))
                 .process(e -> e.getIn().setHeader(FILE_CONTENT_HEADER, CloseShieldInputStream.wrap(e.getIn().getBody(Part.class).getInputStream())))
                 .to("direct:uploadFileAndStartImport")
+                .end()
+                // Replace the multipart parts list left as the body by the splitter with an empty
+                // response body that platform-http can write back to the client.
+                .setBody(constant(""))
                 .routeId("upload-files-and-start-import");
 
 

--- a/src/main/java/no/rutebanken/marduk/security/DefaultMardukAuthorizationService.java
+++ b/src/main/java/no/rutebanken/marduk/security/DefaultMardukAuthorizationService.java
@@ -26,12 +26,8 @@ import org.springframework.security.authentication.AuthenticationManagerResolver
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DefaultMardukAuthorizationService implements MardukAuthorizationService {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultMardukAuthorizationService.class);
 
     private final AuthorizationService<Long> authorizationService;
     private final AuthenticationManagerResolver<HttpServletRequest> resolver;
@@ -105,10 +101,11 @@ public class DefaultMardukAuthorizationService implements MardukAuthorizationSer
             return false;
         }
         if (resolver == null) {
-            // Expected in unit tests not exercising REST; a real platform-http request reaching here
-            // without a resolver means the bean is misconfigured and authorization runs without a principal.
-            LOGGER.warn("No AuthenticationManagerResolver configured: cannot rebuild the Spring Security context for a platform-http request");
-            return false;
+            // Only reachable for a real platform-http request that carries a bearer token: the earlier
+            // guards already returned for non-platform-http exchanges and missing tokens. A null resolver
+            // here means the bean is misconfigured, so fail loudly instead of running the authorization
+            // check without a principal.
+            throw new IllegalStateException("No AuthenticationManagerResolver configured: cannot rebuild the Spring Security context for a platform-http request");
         }
         BearerTokenAuthenticationToken bearer = new BearerTokenAuthenticationToken(encodedToken);
         Authentication authentication = resolver.resolve(platformHttpMessage.getRequest()).authenticate(bearer);

--- a/src/main/java/no/rutebanken/marduk/security/DefaultMardukAuthorizationService.java
+++ b/src/main/java/no/rutebanken/marduk/security/DefaultMardukAuthorizationService.java
@@ -17,14 +17,29 @@
 package no.rutebanken.marduk.security;
 
 
+import jakarta.servlet.http.HttpServletRequest;
+import org.apache.camel.Exchange;
+import org.apache.camel.component.platform.http.springboot.PlatformHttpMessage;
 import org.rutebanken.helper.organisation.authorization.AuthorizationService;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.AuthenticationManagerResolver;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DefaultMardukAuthorizationService implements MardukAuthorizationService {
 
-    private final AuthorizationService<Long> authorizationService;
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultMardukAuthorizationService.class);
 
-    public DefaultMardukAuthorizationService(AuthorizationService<Long> authorizationService) {
+    private final AuthorizationService<Long> authorizationService;
+    private final AuthenticationManagerResolver<HttpServletRequest> resolver;
+
+    public DefaultMardukAuthorizationService(AuthorizationService<Long> authorizationService,
+                                             AuthenticationManagerResolver<HttpServletRequest> resolver) {
         this.authorizationService = authorizationService;
+        this.resolver = resolver;
     }
 
     @Override
@@ -33,13 +48,72 @@ public class DefaultMardukAuthorizationService implements MardukAuthorizationSer
     }
 
     @Override
+    public void verifyAdministratorPrivileges(Exchange exchange) {
+        executeWithSecurityContext(exchange, this::verifyAdministratorPrivileges);
+    }
+
+    @Override
     public void verifyRouteDataEditorPrivileges(Long providerId) {
         authorizationService.validateEditRouteData(providerId);
     }
 
     @Override
+    public void verifyRouteDataEditorPrivileges(Long providerId, Exchange exchange) {
+        executeWithSecurityContext(exchange, () -> verifyRouteDataEditorPrivileges(providerId));
+    }
+
+    @Override
     public void verifyBlockViewerPrivileges(Long providerId) {
         authorizationService.validateViewBlockData(providerId);
+    }
+
+    @Override
+    public void verifyBlockViewerPrivileges(Long providerId, Exchange exchange) {
+        executeWithSecurityContext(exchange, () -> verifyBlockViewerPrivileges(providerId));
+    }
+
+    private void executeWithSecurityContext(Exchange exchange, Runnable authorizationCheck) {
+        boolean contextSet = setSecurityContext(exchange);
+        try {
+            authorizationCheck.run();
+        } finally {
+            if (contextSet) {
+                SecurityContextHolder.clearContext();
+            }
+        }
+    }
+
+    /**
+     * The Camel platform-http component processes requests on an asynchronous worker thread that does
+     * not carry the Spring Security context held in the request thread's {@link SecurityContextHolder}.
+     * When entering a REST route the security context must therefore be rebuilt from the Authorization
+     * header.
+     *
+     * @return true if the security context was set by this method, false otherwise
+     */
+    private boolean setSecurityContext(Exchange exchange) {
+        if (SecurityContextHolder.getContext().getAuthentication() != null) {
+            return false;
+        }
+        if (!(exchange.getIn() instanceof PlatformHttpMessage platformHttpMessage)) {
+            return false;
+        }
+        String encodedToken = exchange.getIn()
+                .getHeader(HttpHeaders.AUTHORIZATION, "", String.class)
+                .replace("Bearer ", "");
+        if (encodedToken.isEmpty()) {
+            return false;
+        }
+        if (resolver == null) {
+            // Expected in unit tests not exercising REST; a real platform-http request reaching here
+            // without a resolver means the bean is misconfigured and authorization runs without a principal.
+            LOGGER.warn("No AuthenticationManagerResolver configured: cannot rebuild the Spring Security context for a platform-http request");
+            return false;
+        }
+        BearerTokenAuthenticationToken bearer = new BearerTokenAuthenticationToken(encodedToken);
+        Authentication authentication = resolver.resolve(platformHttpMessage.getRequest()).authenticate(bearer);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        return true;
     }
 
 }

--- a/src/main/java/no/rutebanken/marduk/security/MardukAuthorizationService.java
+++ b/src/main/java/no/rutebanken/marduk/security/MardukAuthorizationService.java
@@ -1,5 +1,7 @@
 package no.rutebanken.marduk.security;
 
+import org.apache.camel.Exchange;
+
 /**
  *  Service that verifies the privileges of the API clients.
  */
@@ -12,11 +14,23 @@ public interface MardukAuthorizationService {
     void verifyAdministratorPrivileges();
 
     /**
+     * Verify that the user has full administrator privileges, rebuilding the Spring Security context
+     * from the given Camel exchange when invoked from an asynchronous platform-http worker thread.
+     */
+    void verifyAdministratorPrivileges(Exchange exchange);
+
+    /**
      * Verify that the user can edit route data for a given provider.
      * Users can edit route data if they have administrator privileges,
      * or if it has editor privileges for this provider.
      */
     void verifyRouteDataEditorPrivileges(Long providerId);
+
+    /**
+     * Verify that the user can edit route data for a given provider, rebuilding the Spring Security
+     * context from the given Camel exchange when invoked from an asynchronous platform-http worker thread.
+     */
+    void verifyRouteDataEditorPrivileges(Long providerId, Exchange exchange);
 
     /**
      * Verify that the user can read block data for a given provider.
@@ -25,4 +39,10 @@ public interface MardukAuthorizationService {
      * or if they have NeTEx blocks viewer privileges for this provider.
      */
     void verifyBlockViewerPrivileges(Long providerId);
+
+    /**
+     * Verify that the user can read block data for a given provider, rebuilding the Spring Security
+     * context from the given Camel exchange when invoked from an asynchronous platform-http worker thread.
+     */
+    void verifyBlockViewerPrivileges(Long providerId, Exchange exchange);
 }

--- a/src/test/java/no/rutebanken/marduk/rest/AdminRestMardukRouteBuilderIntegrationTest.java
+++ b/src/test/java/no/rutebanken/marduk/rest/AdminRestMardukRouteBuilderIntegrationTest.java
@@ -44,9 +44,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationManagerResolver;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken;
 import org.springframework.security.web.SecurityFilterChain;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -55,6 +59,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -121,6 +126,12 @@ class AdminRestMardukRouteBuilderIntegrationTest extends MardukRouteBuilderInteg
         @Bean
         public AuthorizationService<Long> testAuthorizationService() {
             return new TestAuthorizationService();
+        }
+
+        @Bean
+        public AuthenticationManagerResolver<HttpServletRequest> resolver() {
+            return context -> (AuthenticationManager) authentication ->
+                    new BearerTokenAuthenticationToken(createTestJwtToken().getTokenValue());
         }
 
     }
@@ -196,7 +207,7 @@ class AdminRestMardukRouteBuilderIntegrationTest extends MardukRouteBuilderInteg
 
         // Do rest call
 
-        Map<String, Object> headers = getTestHeaders("POST");
+        Map<String, Object> headers = getTestHeaders("POST", "application/json");
 
         importTemplate.sendBodyAndHeaders(importJson, headers);
 
@@ -225,9 +236,10 @@ class AdminRestMardukRouteBuilderIntegrationTest extends MardukRouteBuilderInteg
         // we must manually start when we are done with all the advice with
         context.start();
 
-        // Do rest call
-        Map<String, Object> headers = getTestHeaders("POST");
-        exportTemplate.sendBodyAndHeaders(null, headers);
+        // Do rest call. ninkasi (via getApiConfig) sends application/json on every call, so the
+        // export trigger must accept it; this guards against re-adding a restrictive consumes().
+        Map<String, Object> headers = getTestHeaders("POST", "application/json");
+        exportTemplate.sendBodyAndHeaders("", headers);
 
         // setup expectations on the mocks
         exportQueue.expectedMessageCount(1);
@@ -425,12 +437,13 @@ class AdminRestMardukRouteBuilderIntegrationTest extends MardukRouteBuilderInteg
         context.start();
 
         String authorizationToken = "Bearer sensitive-secret-token";
-        Map<String, Object> headers = Map.of(
+        Map<String, Object> headers = new HashMap<>(Map.of(
                 Exchange.HTTP_METHOD, "POST",
                 HttpHeaders.AUTHORIZATION, authorizationToken,
-                CHOUETTE_REFERENTIAL, CHOUETTE_REFERENTIAL_RUT);
+                CHOUETTE_REFERENTIAL, CHOUETTE_REFERENTIAL_RUT));
+        headers.put(HttpHeaders.CONTENT_TYPE, "application/json");
 
-        exportTemplate.sendBodyAndHeaders(null, headers);
+        exportTemplate.sendBodyAndHeaders("", headers);
 
         exportQueue.assertIsSatisfied();
 
@@ -448,6 +461,14 @@ class AdminRestMardukRouteBuilderIntegrationTest extends MardukRouteBuilderInteg
                 Exchange.HTTP_METHOD, method,
                 HttpHeaders.AUTHORIZATION, "Bearer test-token",
                 CHOUETTE_REFERENTIAL, CHOUETTE_REFERENTIAL_RUT);
+    }
+
+    // Camel 4 strictly matches the request Content-Type against the route's consumes(), so a POST
+    // must send a Content-Type the endpoint declares or platform-http rejects it with 415.
+    private static Map<String, Object> getTestHeaders(String method, String contentType) {
+        Map<String, Object> headers = new HashMap<>(getTestHeaders(method));
+        headers.put(HttpHeaders.CONTENT_TYPE, contentType);
+        return headers;
     }
 
 }

--- a/src/test/java/no/rutebanken/marduk/rest/AdminRestMardukRouteBuilderIntegrationTest.java
+++ b/src/test/java/no/rutebanken/marduk/rest/AdminRestMardukRouteBuilderIntegrationTest.java
@@ -48,7 +48,6 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationManagerResolver;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
-import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken;
 import org.springframework.security.web.SecurityFilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
@@ -130,8 +129,7 @@ class AdminRestMardukRouteBuilderIntegrationTest extends MardukRouteBuilderInteg
 
         @Bean
         public AuthenticationManagerResolver<HttpServletRequest> resolver() {
-            return context -> (AuthenticationManager) authentication ->
-                    new BearerTokenAuthenticationToken(createTestJwtToken().getTokenValue());
+            return request -> (AuthenticationManager) authentication -> authentication;
         }
 
     }


### PR DESCRIPTION
Migrate from Camel 4.4.5 to 4.18.2, the last line supporting Spring Boot 3 (4.19+ requires Spring Boot 4). Adapt to the breaking changes:

- Replace the removed .validate().predicateExceptionFactory() chain with a process that throws NotFoundException.
- Close nested choice()/filter() blocks with .end() before .endChoice() in AntuNetexValidationStatusRouteBuilder and ChouetteImportRouteBuilder; 4.x endChoice() pops only one level, so a missing .end() silently reattaches later whens/otherwise to the inner block (dropped the IMPORT/OK status).
- Add camel-file-cluster-service-starter and camel-kubernetes-cluster-service-starter; these are no longer pulled in transitively and back the master: endpoint used by singletonFrom().
- Block outbound Camel headers from being copied into PubSub message attributes via a HeaderFilterStrategy, so only the curated ATTRIBUTES map is published (the producer otherwise leaked breadcrumbId and friends).
- Rebuild the Spring Security context from the Authorization header on the platform-http async worker thread, and run removeHttpHeaders only after the authorize step so the header is still present.
- Reset the response body after split-based routes; the platform-http response writer cannot serialize the splitter's leftover list body.
- Disable REST inlineRoutes so /files and /flex/files can both reach the shared direct:adminDatasetUploadFile consumer.
- Drop consumes(text/plain) from the body-less POST trigger endpoints. 4.18 strictly matches the request Content-Type against consumes(), and clients (ninkasi) send application/json, which previously returned 415.

Pin camel-test-spring-junit5 to ${camel.version}; the 4.18 BOM no longer manages it.