### PR TITLE
Fix TypeConversionException on Chouette job submission after Camel 4.18.2 upgrade

### DIFF
--- a/src/main/java/no/rutebanken/marduk/routes/chouette/AbstractChouetteRouteBuilder.java
+++ b/src/main/java/no/rutebanken/marduk/routes/chouette/AbstractChouetteRouteBuilder.java
@@ -43,8 +43,8 @@ public abstract class AbstractChouetteRouteBuilder extends BaseRouteBuilder{
 
 	    exchange.getMessage().setBody(entityBuilder.build());
 	    exchange.getMessage().setHeaders(exchange.getIn().getHeaders());
-	    exchange.getMessage().setHeader(Exchange.CONTENT_TYPE, simple("multipart/form-data"));
-		exchange.getMessage().setHeader(Exchange.HTTP_METHOD, constant(HttpMethods.POST));
+	    exchange.getMessage().setHeader(Exchange.CONTENT_TYPE, "multipart/form-data");
+		exchange.getMessage().setHeader(Exchange.HTTP_METHOD, HttpMethods.POST);
 	}
 
 	protected void toImportMultipart(Exchange exchange) {
@@ -69,7 +69,7 @@ public abstract class AbstractChouetteRouteBuilder extends BaseRouteBuilder{
 
 	    exchange.getMessage().setBody(entityBuilder.build());
 	    exchange.getMessage().setHeaders(exchange.getIn().getHeaders());
-	    exchange.getMessage().setHeader(Exchange.CONTENT_TYPE, simple("multipart/form-data"));
+	    exchange.getMessage().setHeader(Exchange.CONTENT_TYPE, "multipart/form-data");
 	}
 
 


### PR DESCRIPTION
## Problem

Since the Camel 4.18.2 upgrade, every Chouette job submission fails with:

```
org.apache.camel.TypeConversionException: Error during type conversion from type: java.lang.String
to the required type: org.apache.camel.component.http.HttpMethods with value constant{POST}
due to java.lang.IllegalArgumentException: Enum class class org.apache.camel.component.http.HttpMethods
does not have any constant with value: constant{POST}
```

Messages exhaust their redelivery attempts and land in the dead letter queue, affecting the validation, NeTEx export, NeTEx blocks export, and transfer-to-dataspace routes.

## Cause

`AbstractChouetteRouteBuilder.toGenericChouetteMultipart()` set headers from inside a plain Java processor using route-DSL builder syntax:

```java
exchange.getMessage().setHeader(Exchange.HTTP_METHOD, constant(HttpMethods.POST));
```

`constant(...)` returns a Camel `Expression`, which the DSL evaluates but a processor stores verbatim. The `CamelHttpMethod` header therefore contained a `ConstantExpression` object whose `toString()` is `constant{POST}`. Older camel-http versions happened to tolerate this; since 4.18.2 the enum type converter rejects it. The latent bug dates back to 2019 (31bbe85a).

## Fix

Store plain values instead of `Expression` objects:

```java
exchange.getMessage().setHeader(Exchange.CONTENT_TYPE, "multipart/form-data");
exchange.getMessage().setHeader(Exchange.HTTP_METHOD, HttpMethods.POST);
```

The same `simple("multipart/form-data")` anti-pattern in `toImportMultipart()` is cleaned up as well — it only worked by coincidence because `SimpleBuilder.toString()` returns the raw text.

## Testing

All 11 Chouette route integration tests pass, including `ChouetteValidationRouteIntegrationTest` which exercises the failing `chouette-send-validation-job` route.