### PR TITLE
Fix Camel 4.18 pubsub and multipart upload regressions

### DIFF
--- a/helm/marduk/templates/configmap.yaml
+++ b/helm/marduk/templates/configmap.yaml
@@ -15,9 +15,9 @@ data:
     server.compression.enabled=true
 
     # Camel
-    camel.springboot.name=Marduk
-    camel.springboot.streamCachingEnabled=false
-    camel.springboot.streamCachingSpoolEnabled=true
+    camel.main.name=Marduk
+    camel.main.streamCachingEnabled=false
+    camel.main.streamCachingSpoolEnabled=true
     camel.dataformat.jackson.module-refs=jacksonJavaTimeModule
     camel.cluster.kubernetes.enabled=true
     camel.cluster.kubernetes.cluster-labels[app]=marduk

--- a/src/main/java/no/rutebanken/marduk/config/CamelConfig.java
+++ b/src/main/java/no/rutebanken/marduk/config/CamelConfig.java
@@ -19,11 +19,15 @@ package no.rutebanken.marduk.config;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import no.rutebanken.marduk.routes.aggregation.IdleRouteAggregationMonitor;
 import org.apache.camel.CamelContext;
+import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.ThreadPoolBuilder;
 import org.apache.camel.component.google.pubsub.GooglePubsubComponent;
+import org.apache.camel.component.google.pubsub.GooglePubsubEndpoint;
 import org.apache.camel.component.google.pubsub.GooglePubsubHeaderFilterStrategy;
 import org.apache.camel.spi.ComponentCustomizer;
+import org.apache.camel.spi.InterceptSendToEndpoint;
+import org.apache.camel.spring.boot.CamelContextConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -100,6 +104,36 @@ public class CamelConfig {
         return ComponentCustomizer
                 .builder(GooglePubsubComponent.class)
                 .build(component -> component.setHeaderFilterStrategy(new OutboundFilteringHeaderFilterStrategy()));
+    }
+
+    // Camel 4.18 pubsub consumers fetch maxDeliveryAttempts via the Subscriber Admin API (marduk's SA
+    // lacks that permission). Setting it explicitly skips the call; 0 = no client-side enforcement.
+    @Bean
+    CamelContextConfiguration pubsubMaxDeliveryAttemptsDefault() {
+        return new CamelContextConfiguration() {
+            @Override
+            public void beforeApplicationStart(CamelContext camelContext) {
+                camelContext.getCamelContextExtension()
+                        .registerEndpointCallback(CamelConfig::defaultPubsubMaxDeliveryAttempts);
+            }
+
+            @Override
+            public void afterApplicationStart(CamelContext camelContext) {
+                // nothing to do after application start
+            }
+        };
+    }
+
+    static Endpoint defaultPubsubMaxDeliveryAttempts(String uri, Endpoint endpoint) {
+        // interceptSendToEndpoint (BaseRouteBuilder) registers competing endpoint strategies applied in
+        // nondeterministic order, so the endpoint may arrive here already wrapped.
+        Endpoint target = endpoint instanceof InterceptSendToEndpoint intercepted
+                ? intercepted.getOriginalEndpoint()
+                : endpoint;
+        if (target instanceof GooglePubsubEndpoint pubsub && !pubsub.isMaxDeliveryAttemptsExplicitlySet()) {
+            pubsub.setMaxDeliveryAttempts(0);
+        }
+        return endpoint;
     }
 
     static class OutboundFilteringHeaderFilterStrategy extends GooglePubsubHeaderFilterStrategy {

--- a/src/main/java/no/rutebanken/marduk/routes/file/FileUploadRouteBuilder.java
+++ b/src/main/java/no/rutebanken/marduk/routes/file/FileUploadRouteBuilder.java
@@ -21,11 +21,14 @@ import no.rutebanken.marduk.routes.status.JobEvent;
 import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePattern;
 import org.apache.camel.LoggingLevel;
-import org.apache.commons.io.input.CloseShieldInputStream;
+import org.apache.camel.converter.stream.CachedOutputStream;
 import org.apache.tomcat.util.http.fileupload.impl.InvalidContentTypeException;
 import org.springframework.stereotype.Component;
 
 import jakarta.servlet.http.Part;
+
+import java.io.IOException;
+import java.io.InputStream;
 
 import static no.rutebanken.marduk.Constants.*;
 
@@ -35,7 +38,7 @@ import static no.rutebanken.marduk.Constants.*;
 @Component
 public class FileUploadRouteBuilder extends TransactionalBaseRouteBuilder {
 
-    private static final String FILE_CONTENT_HEADER = "RutebankenFileContent";
+    static final String FILE_CONTENT_HEADER = "RutebankenFileContent";
     private static final String CONTENT_TYPE_HEADER = "Content-Type";
 
     @Override
@@ -56,7 +59,7 @@ public class FileUploadRouteBuilder extends TransactionalBaseRouteBuilder {
                 .process(this::setCorrelationIdIfMissing)
                 .setHeader(FILE_NAME, simple("${body.submittedFileName}"))
                 .setHeader(FILE_HANDLE, simple("inbound/received/${header." + CHOUETTE_REFERENTIAL + "}/${header." + FILE_NAME + "}"))
-                .process(e -> e.getIn().setHeader(FILE_CONTENT_HEADER, CloseShieldInputStream.wrap(e.getIn().getBody(Part.class).getInputStream())))
+                .process(FileUploadRouteBuilder::cachePartContent)
                 .to("direct:uploadFileAndStartImport")
                 .end()
                 // Replace the multipart parts list left as the body by the splitter with an empty
@@ -70,6 +73,7 @@ public class FileUploadRouteBuilder extends TransactionalBaseRouteBuilder {
                 .doTry()
                 .log(LoggingLevel.INFO, correlation() + "Uploading timetable file to blob store: ${header." + FILE_HANDLE + "}")
                 .setBody(header(FILE_CONTENT_HEADER))
+                .removeHeader(FILE_CONTENT_HEADER)
                 .setHeader(Exchange.FILE_NAME, header(FILE_NAME))
                 .to("direct:filterDuplicateFile")
                 .to("direct:uploadInternalBlob")
@@ -92,5 +96,17 @@ public class FileUploadRouteBuilder extends TransactionalBaseRouteBuilder {
                 .process(e -> JobEvent.providerJobBuilder(e).timetableAction(JobEvent.TimetableAction.FILE_TRANSFER).state(JobEvent.State.CANCELLED).build()).to(ExchangePattern.InOnly, "direct:updateStatus")
                 .routeId("process-file-after-import");
 
+    }
+
+    // Drain the Part eagerly: on Camel 4.18 platform-http the servlet Part stream is no longer readable
+    // when the downstream upload runs (0-byte blobs). The stream cache spools to disk above the configured
+    // threshold, keeping large uploads off the heap. The JVM test harness does not reproduce the drained
+    // stream; the end-to-end guard is scripts/smoke-upload.sh in the marduk-pipeline superproject.
+    static void cachePartContent(Exchange e) throws IOException {
+        try (InputStream partStream = e.getIn().getBody(Part.class).getInputStream();
+             CachedOutputStream cachedContent = new CachedOutputStream(e)) {
+            partStream.transferTo(cachedContent);
+            e.getIn().setHeader(FILE_CONTENT_HEADER, cachedContent.newStreamCache());
+        }
     }
 }

--- a/src/test/java/no/rutebanken/marduk/config/CamelConfigTest.java
+++ b/src/test/java/no/rutebanken/marduk/config/CamelConfigTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ *
+ */
+
+package no.rutebanken.marduk.config;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.google.pubsub.GooglePubsubEndpoint;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.spi.InterceptSendToEndpoint;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class CamelConfigTest {
+
+    @Test
+    void defaultsMaxDeliveryAttemptsWhenNotSetExplicitly() {
+        GooglePubsubEndpoint endpoint = mock(GooglePubsubEndpoint.class);
+        when(endpoint.isMaxDeliveryAttemptsExplicitlySet()).thenReturn(false);
+
+        assertSame(endpoint, CamelConfig.defaultPubsubMaxDeliveryAttempts("google-pubsub:p:Q", endpoint));
+        verify(endpoint).setMaxDeliveryAttempts(0);
+    }
+
+    @Test
+    void leavesExplicitlyConfiguredEndpointUntouched() {
+        GooglePubsubEndpoint endpoint = mock(GooglePubsubEndpoint.class);
+        when(endpoint.isMaxDeliveryAttemptsExplicitlySet()).thenReturn(true);
+
+        CamelConfig.defaultPubsubMaxDeliveryAttempts("google-pubsub:p:Q?maxDeliveryAttempts=5", endpoint);
+        verify(endpoint, never()).setMaxDeliveryAttempts(anyInt());
+    }
+
+    @Test
+    void defaultsMaxDeliveryAttemptsOnInterceptedEndpoint() {
+        GooglePubsubEndpoint delegate = mock(GooglePubsubEndpoint.class);
+        when(delegate.isMaxDeliveryAttemptsExplicitlySet()).thenReturn(false);
+        InterceptSendToEndpoint wrapper = mock(InterceptSendToEndpoint.class);
+        when(wrapper.getOriginalEndpoint()).thenReturn(delegate);
+
+        assertSame(wrapper, CamelConfig.defaultPubsubMaxDeliveryAttempts("google-pubsub:p:Q", wrapper));
+        verify(delegate).setMaxDeliveryAttempts(0);
+    }
+
+    @Test
+    void ignoresNonPubsubEndpoints() {
+        Endpoint endpoint = mock(Endpoint.class);
+
+        assertSame(endpoint, CamelConfig.defaultPubsubMaxDeliveryAttempts("direct:somewhere", endpoint));
+        verifyNoInteractions(endpoint);
+    }
+
+    @Test
+    void beanDefaultsMaxDeliveryAttemptsOnRealPubsubEndpoint() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            new CamelConfig().pubsubMaxDeliveryAttemptsDefault().beforeApplicationStart(context);
+            context.start();
+
+            GooglePubsubEndpoint endpoint =
+                    context.getEndpoint("google-pubsub:my-project:MyQueue", GooglePubsubEndpoint.class);
+
+            assertTrue(endpoint.isMaxDeliveryAttemptsExplicitlySet());
+            assertEquals(0, endpoint.getMaxDeliveryAttempts());
+        }
+    }
+
+    @Test
+    void beanLeavesExplicitlyConfiguredRealEndpointUntouched() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            new CamelConfig().pubsubMaxDeliveryAttemptsDefault().beforeApplicationStart(context);
+            context.start();
+
+            GooglePubsubEndpoint endpoint = context.getEndpoint(
+                    "google-pubsub:my-project:MyQueue?maxDeliveryAttempts=5", GooglePubsubEndpoint.class);
+
+            assertEquals(5, endpoint.getMaxDeliveryAttempts());
+        }
+    }
+
+    // Production shape: interceptSendToEndpoint (BaseRouteBuilder) registers competing endpoint
+    // strategies applied in nondeterministic order, so the callback may see wrapped endpoints.
+    // Without unwrapping, only a random subset of endpoints gets the default on each start.
+    @Test
+    void beanDefaultsMaxDeliveryAttemptsOnEndpointsWrappedByInterceptors() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            new CamelConfig().pubsubMaxDeliveryAttemptsDefault().beforeApplicationStart(context);
+            for (int i = 0; i < 10; i++) {
+                final int n = i;
+                context.addRoutes(new RouteBuilder() {
+                    @Override
+                    public void configure() {
+                        interceptSendToEndpoint("google-pubsub:*").to("mock:intercepted" + n);
+                        from("direct:in" + n).autoStartup(false).to("google-pubsub:my-project:queue" + n);
+                    }
+                });
+            }
+            context.start();
+
+            for (int i = 0; i < 10; i++) {
+                Endpoint endpoint = context.getEndpoint("google-pubsub:my-project:queue" + i);
+                GooglePubsubEndpoint pubsub = endpoint instanceof InterceptSendToEndpoint intercepted
+                        ? (GooglePubsubEndpoint) intercepted.getOriginalEndpoint()
+                        : (GooglePubsubEndpoint) endpoint;
+                assertEquals(0, pubsub.getMaxDeliveryAttempts(), "queue" + i + " did not get the default");
+                assertTrue(pubsub.isMaxDeliveryAttemptsExplicitlySet());
+            }
+        }
+    }
+}

--- a/src/test/java/no/rutebanken/marduk/routes/chouette/AbstractChouetteRouteBuilderTest.java
+++ b/src/test/java/no/rutebanken/marduk/routes/chouette/AbstractChouetteRouteBuilderTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ *
+ */
+
+package no.rutebanken.marduk.routes.chouette;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.component.http.HttpMethods;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static no.rutebanken.marduk.Constants.FILE_NAME;
+import static no.rutebanken.marduk.Constants.JSON_PART;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AbstractChouetteRouteBuilderTest {
+
+    // concrete subclass to reach the protected helpers
+    private static final class TestChouetteRouteBuilder extends AbstractChouetteRouteBuilder {
+    }
+
+    private final AbstractChouetteRouteBuilder routeBuilder = new TestChouetteRouteBuilder();
+    private DefaultCamelContext context;
+
+    @BeforeEach
+    void setUp() {
+        context = new DefaultCamelContext();
+        context.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        context.stop();
+    }
+
+    // camel-http 4.18 cannot convert a constant(...) Expression on HTTP_METHOD; must be a plain value.
+    @Test
+    void httpMethodHeaderIsAPlainHttpMethod() {
+        Exchange exchange = exchangeWithJsonPart();
+
+        routeBuilder.toGenericChouetteMultipart(exchange);
+
+        HttpMethods httpMethod = assertDoesNotThrow(
+                () -> exchange.getMessage().getHeader(Exchange.HTTP_METHOD, HttpMethods.class),
+                "HTTP_METHOD must be a plain HttpMethods value, not a constant(...) Expression");
+        assertEquals(HttpMethods.POST, httpMethod);
+    }
+
+    // Same anti-pattern: CONTENT_TYPE must be a plain String, not a simple(...) Expression.
+    @Test
+    void contentTypeHeaderIsAPlainString() {
+        Exchange genericExchange = exchangeWithJsonPart();
+        routeBuilder.toGenericChouetteMultipart(genericExchange);
+        assertEquals("multipart/form-data", genericExchange.getMessage().getHeader(Exchange.CONTENT_TYPE));
+
+        Exchange importExchange = exchangeWithJsonPart();
+        importExchange.getIn().setHeader(FILE_NAME, "netex.zip");
+        importExchange.getIn().setBody("payload".getBytes(StandardCharsets.UTF_8));
+        routeBuilder.toImportMultipart(importExchange);
+        assertEquals("multipart/form-data", importExchange.getMessage().getHeader(Exchange.CONTENT_TYPE));
+    }
+
+    private Exchange exchangeWithJsonPart() {
+        Exchange exchange = new DefaultExchange(context);
+        exchange.getIn().setHeader(JSON_PART, "{}".getBytes(StandardCharsets.UTF_8));
+        return exchange;
+    }
+}

--- a/src/test/java/no/rutebanken/marduk/routes/file/FileUploadContentCacheTest.java
+++ b/src/test/java/no/rutebanken/marduk/routes/file/FileUploadContentCacheTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ *
+ */
+
+package no.rutebanken.marduk.routes.file;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.StreamCache;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.servlet.http.Part;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class FileUploadContentCacheTest {
+
+    private DefaultCamelContext context;
+
+    // Replicate the production stream caching config: globally disabled, per-route opt-in, disk spool
+    // enabled. The route-level opt-in is what enables the context-wide strategy at startup.
+    @BeforeEach
+    void setUp() throws Exception {
+        context = new DefaultCamelContext();
+        context.setStreamCaching(false);
+        context.getStreamCachingStrategy().setSpoolEnabled(true);
+        context.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:streamCachingOptIn").streamCaching().to("mock:sink");
+            }
+        });
+        context.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        context.stop();
+    }
+
+    @Test
+    void spoolsLargePartToDiskAndSupportsRepeatedReads() throws Exception {
+        byte[] content = new byte[512 * 1024];
+        new Random(42).nextBytes(content);
+
+        StreamCache cache = cachePart(content);
+
+        assertFalse(cache.inMemory(), "content above the spool threshold must not be held on the heap");
+        assertArrayEquals(content, readFully(cache));
+        cache.reset();
+        assertArrayEquals(content, readFully(cache), "cache must be re-readable after reset (digest + upload)");
+    }
+
+    @Test
+    void keepsSmallPartInMemory() throws Exception {
+        byte[] content = "small part".getBytes(StandardCharsets.UTF_8);
+
+        StreamCache cache = cachePart(content);
+
+        assertTrue(cache.inMemory());
+        assertArrayEquals(content, readFully(cache));
+    }
+
+    private StreamCache cachePart(byte[] content) throws Exception {
+        Part part = mock(Part.class);
+        when(part.getInputStream()).thenReturn(new ByteArrayInputStream(content));
+        Exchange exchange = new DefaultExchange(context);
+        exchange.getIn().setBody(part);
+
+        FileUploadRouteBuilder.cachePartContent(exchange);
+
+        return exchange.getIn().getHeader(FileUploadRouteBuilder.FILE_CONTENT_HEADER, StreamCache.class);
+    }
+
+    private static byte[] readFully(StreamCache cache) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        cache.writeTo(out);
+        return out.toByteArray();
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -21,9 +21,9 @@ spring.servlet.multipart.max-file-size=100MB
 spring.servlet.multipart.max-request-size=100MB
 
 # Camel
-camel.springboot.name=Marduk
-camel.springboot.streamCachingEnabled=false
-camel.springboot.streamCachingSpoolEnabled=true
+camel.main.name=Marduk
+camel.main.streamCachingEnabled=false
+camel.main.streamCachingSpoolEnabled=true
 camel.dataformat.jackson.module-refs=jacksonJavaTimeModule
 marduk.camel.redelivery.max=0
 camel.cluster.kubernetes.enabled=false


### PR DESCRIPTION
- Default maxDeliveryAttempts=0 on pubsub endpoints to skip the startup
  Subscriber Admin API call the service account lacks permission for;
  unwrap intercepted endpoints since endpoint strategies apply in
  nondeterministic order
- Drain multipart upload Parts eagerly into a disk-spooling stream cache;
  4.18 platform-http leaves the Part stream unreadable by the time the
  blob upload runs, storing 0-byte blobs
- Rename camel.springboot.* properties to camel.main.*; 4.18 silently
  ignores the old prefix, leaving stream caching on defaults (no spool)
- Add regression tests, including for the Chouette multipart header fix
  from PR https://github.com/entur/marduk/pull/810